### PR TITLE
chore(config): remove local .poe-code-ralph pointer

### DIFF
--- a/.poe-code-ralph
+++ b/.poe-code-ralph
@@ -1,1 +1,0 @@
-/Users/kjopek/Workspace/poe-setup-scripts/.poe-code-ralph


### PR DESCRIPTION
## Summary
  - Remove `.poe-code-ralph` from the repository.

  ## Why
  - The file points to a local machine path and should not be versioned.
  - Removing it keeps the repo portable and avoids environment-specific config leaks.

  ## Testing
  - Not run (non-functional cleanup; no runtime code changes).