### PR TITLE
feat(goose): fetch model context limits and store secrets in secrets.yaml

### DIFF
--- a/.poe-code/pipeline/plans/archive/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/archive/plan-goose-agent.yaml
@@ -335,4 +335,4 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -1,0 +1,338 @@
+vars:
+  research_doc: "{{file 'docs/research/goose-agent-investigation.md'}}"
+
+tasks:
+  - id: agent-def
+    title: Create Goose agent definition and register it
+    prompt: |
+      Add Goose as a new agent in poe-code.
+
+      Research context: {{research_doc}}
+
+      ## 1. Create `packages/agent-defs/src/agents/goose.ts`
+
+      Define the Goose agent following the existing pattern (see opencode.ts, kimi.ts):
+
+      ```typescript
+      export const gooseAgent: AgentDefinition = {
+        id: "goose",
+        name: "goose",
+        label: "Goose",
+        summary: "Block's open-source AI agent with ACP support.",
+        binaryName: "goose",
+        configPath: "~/.config/goose/config.yaml",
+        branding: {
+          colors: {
+            dark: "#FF6B35",
+            light: "#E85D26"
+          }
+        }
+      };
+      ```
+
+      ## 2. Export from `packages/agent-defs/src/agents/index.ts`
+
+      Add: `export { gooseAgent } from "./goose.js";`
+
+      ## 3. Register in `packages/agent-defs/src/registry.ts`
+
+      Import `gooseAgent` and add it to the `allAgents` array.
+
+      ## 4. Add to `src/cli/constants.ts`
+
+      Add Goose to the model/agent constants where other agents are listed.
+
+      ## 5. Run tests
+
+      Run `npm run build` and the agent-defs test suite to confirm everything compiles and resolves correctly.
+    status:
+      implement: done
+      test: done
+      commit: open
+
+  - id: yaml-config-support
+    title: Add YAML config format to agent-mcp-config
+    prompt: |
+      Add YAML config format support to `packages/agent-mcp-config` so Goose MCP entries can be written.
+
+      Research context: {{research_doc}}
+
+      Goose stores MCP servers under the `extensions` key in `~/.config/goose/config.yaml` as YAML.
+
+      ## 1. Install yaml parser
+
+      Add the `yaml` package to `packages/agent-mcp-config` dependencies (the same one used in the ralph package).
+
+      ## 2. Add YAML format support in `packages/agent-mcp-config/src/configs.ts`
+
+      Extend the `ConfigFormat` type to include `"yaml"`.
+      Update the config read/write logic to handle YAML parsing and serialization using the `yaml` package.
+
+      ## 3. Add Goose MCP config entry
+
+      Add to the `agentMcpConfigs` record:
+
+      ```typescript
+      goose: {
+        configFile: "~/.config/goose/config.yaml",
+        configKey: "extensions",
+        format: "yaml",
+        shape: "goose"    // Goose uses a different shape for MCP entries
+      }
+      ```
+
+      Goose MCP extension entries look like:
+      ```yaml
+      extensions:
+        my-server:
+          type: stdio
+          cmd: npx
+          args:
+            - my-mcp-server
+          envs:
+            API_KEY: "..."
+      ```
+
+      The shape differs from the standard shape: it uses `cmd` instead of `command`, and `envs` instead of `env`. Add a `"goose"` shape handler.
+
+      ## 4. Tests
+
+      Write tests using memfs for:
+      - Reading existing YAML config and merging an MCP entry
+      - Writing a new YAML config when none exists
+      - The goose shape transformation (command→cmd, env→envs)
+      - Round-trip: write then read preserves entries
+    status:
+      implement: open
+      test: open
+      commit: open
+
+  - id: provider
+    title: Create Goose provider with configure/unconfigure
+    prompt: |
+      Create the Goose provider file implementing configure, unconfigure, install, and test.
+
+      Research context: {{research_doc}}
+
+      ## Create `src/providers/goose.ts`
+
+      Use `createProvider()` following the pattern in opencode.ts and codex.ts.
+
+      ### Configure strategy
+
+      Use a Goose **custom provider** for Poe integration. Configure must:
+
+      1. Ensure `~/.config/goose/custom_providers/` directory exists
+      2. Write `~/.config/goose/custom_providers/custom_poe.json`:
+         ```json
+         {
+           "name": "custom_poe",
+           "engine": "openai",
+           "display_name": "Poe",
+           "description": "Poe OpenAI-compatible API",
+           "api_key_env": "CUSTOM_POE_API_KEY",
+           "base_url": "https://api.poe.com/v1/chat/completions",
+           "models": [<model list from context>],
+           "supports_streaming": true,
+           "requires_auth": true
+         }
+         ```
+      3. Merge into `~/.config/goose/config.yaml`:
+         ```yaml
+         GOOSE_PROVIDER: custom_poe
+         GOOSE_MODEL: <selected model>
+         ```
+
+      Important: Goose config is YAML, not JSON. Use `configMutation.merge` with the yaml format if available, or use `fileMutation` to write the config. Check how other providers handle non-JSON config (e.g. codex uses TOML).
+
+      ### Unconfigure
+
+      1. Remove the `custom_poe.json` custom provider file
+      2. Prune `GOOSE_PROVIDER` and `GOOSE_MODEL` from config.yaml if they match Poe values
+
+      ### Install
+
+      Support both Homebrew (`brew install block-goose-cli`) and the release installer script.
+
+      ### Test
+
+      Use `goose run --text "Reply with exactly: GOOSE_OK" --output-format text` as the health check.
+
+      ### Isolated environment
+
+      Use `GOOSE_PATH_ROOT` to redirect config/data/state directories:
+      ```typescript
+      isolatedEnv: {
+        agentBinary: "goose",
+        configProbe: { kind: "isolatedFile", relativePath: ".config/goose/config.yaml" },
+        env: {
+          GOOSE_PATH_ROOT: { kind: "isolatedDir", relativePath: "" }
+        }
+      }
+      ```
+
+      ### Configure prompts
+
+      Prompt for model selection (use the standard model prompt pattern).
+
+      ## Export
+
+      Export as `export const provider = gooseService;`
+    status:
+      implement: open
+      test: open
+      commit: open
+
+  - id: spawn-config
+    title: Add Goose CLI and ACP spawn configs
+    prompt: |
+      Add spawn configuration for Goose so `poe-code spawn goose` works.
+
+      Research context: {{research_doc}}
+
+      ## 1. Create `packages/agent-spawn/src/configs/goose.ts`
+
+      ### CLI spawn config
+
+      ```typescript
+      export const gooseSpawnConfig: CliSpawnConfig = {
+        kind: "cli",
+        agentId: "goose",
+        adapter: "native",   // or create a goose adapter if stream-json needs custom parsing
+        promptFlag: "--text",
+        modelFlag: "--model",
+        modelStripProviderPrefix: false,
+        defaultArgs: ["run", "--output-format", "stream-json"],
+        modes: {
+          yolo: [],
+          edit: [],
+          read: []
+        },
+        stdinMode: {
+          omitPrompt: true,
+          extraArgs: ["--instructions", "-"]
+        },
+        interactive: {
+          defaultArgs: ["session"],
+          promptFlag: undefined
+        },
+        resumeCommand: (threadId, cwd) => ["run", "--resume", "--text", "continue"]
+      };
+      ```
+
+      Note: `promptFlag: "--text"` is used with the `run` subcommand. The `run` is in `defaultArgs`. Verify this produces correct argument order: `goose run --output-format stream-json --text "prompt" --model model`.
+
+      ### ACP spawn config
+
+      Goose supports ACP natively via `goose acp`:
+
+      ```typescript
+      export const gooseAcpSpawnConfig: AcpSpawnConfig = {
+        kind: "acp",
+        agentId: "goose",
+        acpArgs: ["acp"],
+        skipAuth: true
+      };
+      ```
+
+      ## 2. Register in `packages/agent-spawn/src/configs/index.ts`
+
+      Import and add `gooseSpawnConfig` to `allSpawnConfigs`.
+      Import and add `gooseAcpSpawnConfig` to the `acpLookup` map.
+
+      ## 3. MCP spawn args
+
+      Add a Goose MCP serializer in `packages/agent-spawn/src/configs/mcp.ts` if needed.
+      Goose supports `--with-extension` for runtime MCP:
+      ```
+      goose run --with-extension "cmd arg1 arg2" --text "prompt"
+      ```
+
+      Create `serializeGooseMcpArgs`:
+      ```typescript
+      export function serializeGooseMcpArgs(servers: McpSpawnConfig): string[] {
+        return Object.values(servers).flatMap((server) => [
+          "--with-extension",
+          [server.command, ...(server.args ?? [])].join(" ")
+        ]);
+      }
+      ```
+
+      Wire it into the spawn config via `mcpArgs`.
+
+      ## 4. Tests
+
+      Write tests for:
+      - CLI spawn config produces correct args
+      - ACP config is registered
+      - MCP serializer produces correct `--with-extension` args
+    status:
+      implement: open
+      test: open
+      commit: open
+
+  - id: skill-config
+    title: Add Goose skill directory config
+    prompt: |
+      Add Goose skill directory support.
+
+      Research context: {{research_doc}}
+
+      ## Update `packages/agent-skill-config/src/configs.ts`
+
+      Add Goose entry to `agentSkillConfigs`:
+
+      ```typescript
+      goose: {
+        globalSkillDir: "~/.agents/skills",
+        localSkillDir: ".agents/skills"
+      }
+      ```
+
+      Per the research doc, Goose scans multiple skill directories, but `.agents/skills` is the best practical choice that aligns with cross-agent conventions.
+
+      ## Tests
+
+      Write tests verifying:
+      - Goose agent is supported in skill config
+      - Skill directories resolve correctly
+    status:
+      implement: open
+      test: open
+      commit: open
+
+  - id: integration-test
+    title: Spot-test Goose integration end-to-end
+    prompt: |
+      Verify the full Goose integration works by running spot tests.
+
+      ## 1. Build
+
+      Run `npm run build` and fix any compilation errors.
+
+      ## 2. Screenshot tests
+
+      Run visual spot checks:
+      ```
+      npm run screenshot-poe-code -- configure --help
+      npm run screenshot-poe-code -- spawn --help
+      npm run screenshot-poe-code -- mcp --help
+      ```
+
+      Verify Goose appears in the agent lists.
+
+      ## 3. Verify agent resolution
+
+      ```
+      npm run dev -- test goose --dry-run
+      ```
+
+      Or test via the SDK that `resolveAgentId("goose")` returns `"goose"`.
+
+      ## 4. Fix any issues found
+
+      Fix compilation errors, missing registrations, or visual problems.
+    status:
+      implement: open
+      test: open
+      commit: open

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -105,7 +105,7 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done
 
   - id: provider
     title: Create Goose provider with configure/unconfigure
@@ -179,8 +179,8 @@ tasks:
 
       Export as `export const provider = gooseService;`
     status:
-      implement: open
-      test: open
+      implement: done
+      test: done
       commit: open
 
   - id: spawn-config

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -181,7 +181,7 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done
 
   - id: spawn-config
     title: Add Goose CLI and ACP spawn configs
@@ -267,8 +267,8 @@ tasks:
       - ACP config is registered
       - MCP serializer produces correct `--with-extension` args
     status:
-      implement: open
-      test: open
+      implement: done
+      test: done
       commit: open
 
   - id: skill-config

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -48,7 +48,7 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done
 
   - id: yaml-config-support
     title: Add YAML config format to agent-mcp-config
@@ -103,8 +103,8 @@ tasks:
       - The goose shape transformation (command→cmd, env→envs)
       - Round-trip: write then read preserves entries
     status:
-      implement: open
-      test: open
+      implement: done
+      test: done
       commit: open
 
   - id: provider

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -269,7 +269,7 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done
 
   - id: skill-config
     title: Add Goose skill directory config
@@ -297,8 +297,8 @@ tasks:
       - Goose agent is supported in skill config
       - Skill directories resolve correctly
     status:
-      implement: open
-      test: open
+      implement: done
+      test: done
       commit: open
 
   - id: integration-test

--- a/.poe-code/pipeline/plans/plan-goose-agent.yaml
+++ b/.poe-code/pipeline/plans/plan-goose-agent.yaml
@@ -299,7 +299,7 @@ tasks:
     status:
       implement: done
       test: done
-      commit: open
+      commit: done
 
   - id: integration-test
     title: Spot-test Goose integration end-to-end
@@ -333,6 +333,6 @@ tasks:
 
       Fix compilation errors, missing registrations, or visual problems.
     status:
-      implement: open
-      test: open
+      implement: done
+      test: done
       commit: open

--- a/docs/plans/goose-agent-acp.md
+++ b/docs/plans/goose-agent-acp.md
@@ -1,0 +1,701 @@
+# Plan: Add Goose as an ACP-first agent
+
+## Goal
+
+Add Goose to `poe-code` as a first-class agent using **ACP as the primary spawn path**.
+
+This plan covers:
+
+- install
+- configure
+- test
+- spawn via ACP
+- MCP support
+- skills support
+
+This plan intentionally treats Goose as a **normal `poe-code` integration** with Goose-specific config/mapping work, not as a one-off exception.
+
+---
+
+## Verified facts
+
+These were re-checked against the current `poe-code` and Goose source trees.
+
+### Goose configuration and install
+
+- Goose CLI binary is `goose`.
+- Goose config file is:
+  - macOS/Linux: `~/.config/goose/config.yaml`
+  - Windows: `%APPDATA%\Block\goose\config\config.yaml`
+- Goose can store secrets in:
+  - environment variables
+  - keyring
+  - `secrets.yaml` fallback
+- Setting `GOOSE_DISABLE_KEYRING: true` in `config.yaml` is enough to force file-based secrets.
+- Goose custom providers live in:
+  - `~/.config/goose/custom_providers/*.json`
+- Goose CLI install options already documented upstream:
+  - `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash`
+  - `brew install block-goose-cli`
+- Goose source build path is valid:
+  - `cargo build`
+  - `cargo run -p goose-cli -- ...`
+
+### Goose ACP
+
+- Goose has a native ACP server: `goose acp`.
+- `goose acp` advertises:
+  - session support
+  - load session support
+  - MCP HTTP capability (`http: true`)
+  - ACP auth methods
+- Goose ACP **does implement authenticate**; `skipAuth` is **not** needed.
+- Goose ACP new sessions load enabled extensions from `config.yaml` and then merge any builtins passed to `goose acp --with-builtin ...`.
+- Goose ACP accepts MCP servers in `session/new` and converts them to Goose extensions.
+- Goose ACP exposes custom extension methods, including:
+  - `_goose/config/extensions`
+  - `_goose/extensions/add`
+  - `_goose/extensions/remove`
+  - `_goose/session/provider/update`
+
+### Goose extensions / MCP / skills
+
+- Goose stores persistent MCP-like configuration under `extensions:` in `config.yaml`.
+- Goose extension entry types include:
+  - `stdio`
+  - `streamable_http`
+  - `builtin`
+  - `platform`
+- Goose does **not** support SSE for extensions anymore.
+- Goose skills now require the **Summon** platform extension.
+- Recommended Goose skill directories are:
+  - local: `.agents/skills`
+  - global: `~/.agents/skills`
+- Goose still supports several legacy skill directories, but `.agents/skills` is the recommended standard.
+- The **Developer** and **Summon** platform extensions are both marked upstream as `default_enabled: true`, but `poe-code` should not rely on Goose bootstrapping them for us — we should write them explicitly when needed.
+
+### Current `poe-code` state
+
+- `packages/config-mutations` currently supports only `json` and `toml` formats.
+- `packages/agent-mcp-config` currently supports only `json` and `toml` config files.
+- `packages/agent-mcp-config` already supports both MCP transports at the data model level:
+  - `stdio`
+  - `http`
+- `packages/agent-spawn` already supports ACP spawn and already passes MCP servers in `session/new`.
+- `packages/poe-acp-client` already supports:
+  - ACP auth
+  - MCP HTTP server types
+  - custom extension requests via `sendExtRequest()`
+- **Important shared gap:** current ACP spawn code in `packages/agent-spawn/src/acp/spawn-acp.ts` does **not** use `options.model`.
+  - This is already a shared ACP limitation, not a Goose-only problem.
+- Current spawn-time MCP input type in `packages/agent-spawn` is still stdio-shaped (`{command,args?,env?}`), so HTTP MCP at spawn is not yet fully modeled there, even though `poe-acp-client` and Goose ACP can support it.
+
+---
+
+## Decisions
+
+## 1. Use ACP as the primary Goose spawn path
+
+Do **not** build Goose support around `stream-json`.
+
+Implementation target:
+
+- add `AcpSpawnConfig` for Goose
+- use `goose acp`
+- treat CLI `goose run` only as a fallback for manual debugging, not as the main integration path
+
+## 2. Configure Goose through a custom Poe provider
+
+Do **not** overload Goose’s built-in `openai` provider.
+
+Write a custom provider file:
+
+- `~/.config/goose/custom_providers/custom_poe.json`
+
+and set:
+
+- `GOOSE_PROVIDER: custom_poe`
+- `GOOSE_MODEL: <selected-model>`
+
+## 3. Use file-based secrets only
+
+For `poe-code`, force the simple path:
+
+- write `GOOSE_DISABLE_KEYRING: true`
+- write API key to `~/.config/goose/secrets.yaml`
+
+No keyring integration in phase 1.
+
+## 4. Treat MCP as required for support
+
+Goose support is not considered complete without MCP.
+
+That means phase 1 must include:
+
+- persistent MCP config in `config.yaml`
+- ACP-session MCP injection support for the currently supported spawn MCP abstraction
+
+## 5. Treat skills as required enough to wire from the start
+
+Skills support should include:
+
+- `~/.agents/skills`
+- `.agents/skills`
+- explicit enablement of Summon in Goose config
+
+---
+
+## Goose-specific config shapes to write
+
+## A. `config.yaml`
+
+Minimum managed keys:
+
+```yaml
+GOOSE_DISABLE_KEYRING: true
+GOOSE_PROVIDER: custom_poe
+GOOSE_MODEL: openai/gpt-5.4
+extensions:
+  developer:
+    enabled: true
+    type: platform
+    name: developer
+    description: Write and edit files, and execute shell commands
+    display_name: Developer
+    bundled: true
+    available_tools: []
+  summon:
+    enabled: true
+    type: platform
+    name: summon
+    description: Load knowledge and delegate tasks to subagents
+    display_name: Summon
+    bundled: true
+    available_tools: []
+```
+
+Notes:
+
+- `developer` is required for useful ACP file/shell workflows.
+- `summon` is required for skills.
+- MCP entries will also be written under the same `extensions:` map.
+
+## B. `secrets.yaml`
+
+```yaml
+CUSTOM_POE_API_KEY: <poe api key>
+```
+
+## C. `custom_providers/custom_poe.json`
+
+```json
+{
+  "name": "custom_poe",
+  "engine": "openai",
+  "display_name": "Poe",
+  "description": "Poe OpenAI-compatible API",
+  "api_key_env": "CUSTOM_POE_API_KEY",
+  "base_url": "https://api.poe.com/v1/chat/completions",
+  "models": [
+    { "name": "openai/gpt-5.4", "context_limit": 128000 }
+  ],
+  "supports_streaming": true,
+  "requires_auth": true
+}
+```
+
+Notes:
+
+- The `models` array should be generated from `src/cli/constants.ts`, not hardcoded ad hoc.
+- Use the exact Poe model IDs that `poe-code` already exposes.
+
+---
+
+## MCP plan
+
+## Scope
+
+Support both:
+
+1. **persistent MCP config** via `poe-code mcp ...`
+2. **ACP-session MCP injection** for spawn flows
+
+## Persistent MCP config for Goose
+
+Add Goose to `packages/agent-mcp-config` with a Goose-specific YAML shape.
+
+### Config file
+
+- macOS/Linux: `~/.config/goose/config.yaml`
+- Windows: `~/AppData/Roaming/Block/goose/config/config.yaml` (through platform resolver)
+
+### Config key
+
+- `extensions`
+
+### Required new format support
+
+Add `yaml` support to:
+
+- `packages/config-mutations`
+- `packages/agent-mcp-config`
+
+### Required new shape
+
+Add a new `goose` shape transformer in `packages/agent-mcp-config/src/shapes.ts`.
+
+#### Stdio MCP server
+
+Input:
+
+```ts
+{
+  name: "github",
+  config: {
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-github"],
+    env: { GITHUB_PERSONAL_ACCESS_TOKEN: "..." }
+  }
+}
+```
+
+Output under `extensions.github`:
+
+```yaml
+github:
+  enabled: true
+  type: stdio
+  name: github
+  description: github
+  cmd: npx
+  args:
+    - -y
+    - "@modelcontextprotocol/server-github"
+  envs:
+    GITHUB_PERSONAL_ACCESS_TOKEN: ...
+  timeout: 300
+  available_tools: []
+```
+
+#### HTTP MCP server
+
+Input:
+
+```ts
+{
+  name: "remote",
+  config: {
+    transport: "http",
+    url: "https://example.com/mcp",
+    headers: { Authorization: "Bearer ..." }
+  }
+}
+```
+
+Output under `extensions.remote`:
+
+```yaml
+remote:
+  enabled: true
+  type: streamable_http
+  name: remote
+  description: remote
+  uri: https://example.com/mcp
+  headers:
+    Authorization: Bearer ...
+  envs: {}
+  timeout: 300
+  available_tools: []
+```
+
+### Key choice
+
+Use Goose-style normalized extension keys, i.e. the equivalent of Goose’s `name_to_key(name)`.
+
+That keeps `poe-code` output aligned with Goose’s own config behavior.
+
+## ACP-session MCP injection
+
+### What already works
+
+`packages/agent-spawn` already sends MCP servers in ACP `session/new`.
+
+Goose ACP already converts session MCP servers into Goose extension configs.
+
+### What to support in phase 1
+
+- stdio MCP servers over ACP session/new
+
+### What is a shared follow-up
+
+If we want HTTP MCP servers at spawn time through `poe-code spawn`, widen the generic spawn MCP types in `packages/agent-spawn` from stdio-only to a union that also models HTTP.
+
+This is a **shared ACP improvement**, not a Goose-specific hack.
+
+---
+
+## Skills plan
+
+Add Goose to `packages/agent-skill-config` as:
+
+```ts
+{
+  globalSkillDir: "~/.agents/skills",
+  localSkillDir: ".agents/skills"
+}
+```
+
+### Additional configure behavior
+
+`poe-code configure goose` must ensure the `summon` platform extension is enabled in Goose config.
+
+### Do not use legacy skill directories
+
+Do not expose legacy Goose skill directories in `poe-code`.
+
+Use the standard Agent Skills directories only:
+
+- `~/.agents/skills`
+- `.agents/skills`
+
+That matches the current Goose docs and keeps skills portable across agents.
+
+---
+
+## ACP model/provider plan
+
+This is the most important shared ACP gap surfaced by Goose.
+
+## Verified issue
+
+`packages/agent-spawn/src/acp/spawn-acp.ts` currently ignores `options.model`.
+
+That means a Goose ACP integration would otherwise only use the default model from `config.yaml`.
+
+## Required behavior
+
+`poe-code spawn goose --model ...` and SDK `spawn({ model })` must work.
+
+## Recommended implementation
+
+Add a post-session initialization hook to ACP spawn configs.
+
+Example shape:
+
+```ts
+interface AcpSpawnConfig {
+  kind: "acp";
+  agentId: string;
+  acpArgs: string[];
+  skipAuth?: boolean;
+  mcpEnv?: ...;
+  afterNewSession?: (args) => Promise<void>;
+}
+```
+
+Then Goose can use:
+
+- `client.sendExtRequest("_goose/session/provider/update", ...)`
+
+with:
+
+- `sessionId`
+- `provider: "custom_poe"`
+- `model: <resolved-model>`
+
+### Why this is the right approach
+
+- uses Goose’s own supported ACP extension method
+- keeps Goose ACP as the main path
+- preserves CLI/SDK model parity
+- avoids inventing Goose-only env hacks for spawn-time model selection
+
+### Minimal fallback if we want to phase this
+
+Phase 1 can configure the default model correctly in `config.yaml`, but the plan should still treat per-spawn model override as required work before calling Goose support complete.
+
+---
+
+## Install plan
+
+Add Goose install support in `src/providers/goose.ts`.
+
+### Binary check
+
+- binary name: `goose`
+
+### Install steps
+
+Use platform-specific install commands:
+
+#### macOS / Linux
+
+```sh
+sh -c 'curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash'
+```
+
+#### Windows
+
+Use the PowerShell installer path documented upstream.
+
+### Why `CONFIGURE=false`
+
+`poe-code` should own configuration. Installer should only install the binary.
+
+---
+
+## Concrete file plan
+
+## 1. Agent definition
+
+Add:
+
+- `packages/agent-defs/src/agents/goose.ts`
+- export from `packages/agent-defs/src/agents/index.ts`
+- register in `packages/agent-defs/src/registry.ts`
+
+Proposed basics:
+
+- `id: "goose"`
+- `name: "goose"`
+- `label: "Goose"`
+- `binaryName: "goose"`
+- `configPath: "~/.config/goose/config.yaml"`
+
+## 2. Provider
+
+Add:
+
+- `src/providers/goose.ts`
+
+Responsibilities:
+
+- configure custom Poe provider
+- write `config.yaml`
+- write `secrets.yaml`
+- enable `developer`
+- enable `summon`
+- install Goose
+- custom ACP-aware health check
+
+## 3. Shared config mutation support
+
+Extend:
+
+- `packages/config-mutations/src/types.ts`
+- `packages/config-mutations/src/mutations/config-mutation.ts`
+- `packages/config-mutations/src/formats/*`
+- `packages/config-mutations/src/execution/apply-mutation.ts`
+- related tests
+
+Add `yaml` as a supported config format.
+
+## 4. MCP config package
+
+Extend:
+
+- `packages/agent-mcp-config/src/configs.ts`
+- `packages/agent-mcp-config/src/shapes.ts`
+- `packages/agent-mcp-config/src/apply.ts`
+- tests
+
+Add:
+
+- `format: "yaml"`
+- `shape: "goose"`
+
+## 5. Skill config package
+
+Extend:
+
+- `packages/agent-skill-config/src/configs.ts`
+- tests
+
+Add Goose skill directory mapping.
+
+## 6. ACP spawn config
+
+Add:
+
+- `packages/agent-spawn/src/configs/goose.ts`
+- register in `packages/agent-spawn/src/configs/index.ts`
+
+Proposed config:
+
+```ts
+{
+  kind: "acp",
+  agentId: "goose",
+  acpArgs: ["acp"]
+}
+```
+
+No `skipAuth`.
+
+## 7. Shared ACP post-session hook
+
+Extend:
+
+- `packages/agent-spawn/src/types.ts`
+- `packages/agent-spawn/src/acp/spawn-acp.ts`
+- tests
+
+So Goose can call `_goose/session/provider/update` after session creation.
+
+## 8. CLI constants
+
+Extend:
+
+- `src/cli/constants.ts`
+
+Add a Goose model list + default, probably derived from existing frontier/Poe-safe model list rather than inventing a Goose-only list.
+
+---
+
+## Test plan
+
+## Unit tests
+
+### `packages/config-mutations`
+
+- YAML detect/parse/serialize/merge/prune/transform
+- preserve unrelated YAML keys
+- deep merge `extensions`
+
+### `packages/agent-mcp-config`
+
+- Goose stdio entry serialization
+- Goose HTTP entry serialization
+- Goose unconfigure removes only the target extension entry
+- existing `developer` / `summon` entries remain untouched
+
+### `packages/agent-skill-config`
+
+- Goose global/local skill dir resolution
+
+### `packages/agent-spawn`
+
+- Goose ACP config resolution
+- Goose ACP spawn path uses `goose acp`
+- Goose post-session hook sends `_goose/session/provider/update`
+- Goose ACP new session receives MCP servers
+
+### `src/providers/providers.test.ts`
+
+- configure writes:
+  - `config.yaml`
+  - `secrets.yaml`
+  - `custom_providers/custom_poe.json`
+- unconfigure behavior, if included
+- install definition
+
+## Spot tests
+
+- `npm run dev -- configure goose --yes`
+- `npm run dev -- test goose`
+- `npm run dev -- spawn goose "Output exactly: GOOSE_OK"`
+- `npm run dev -- mcp add goose ...`
+- `npm run dev -- skill add goose ...` if applicable to existing commands
+
+## Screenshot checks
+
+Required for any CLI UX touched by Goose integration:
+
+- `npm run screenshot-poe-code -- configure goose`
+- `npm run screenshot-poe-code -- spawn goose "hello"`
+- any MCP/skills command UX touched
+
+---
+
+## Phase order
+
+## Phase 1 — shared prerequisites
+
+1. add YAML support to `config-mutations`
+2. add YAML support to `agent-mcp-config`
+3. add Goose MCP shape
+
+## Phase 2 — configure/install/skills
+
+1. add Goose agent definition
+2. add `src/providers/goose.ts`
+3. write custom provider + config + secrets
+4. add Goose skill dir mapping
+5. ensure `developer` + `summon`
+6. add install definition
+
+## Phase 3 — ACP spawn
+
+1. add Goose ACP spawn config
+2. verify `goose acp` works through existing `spawnAcp`
+3. add Goose-specific post-session provider/model update hook
+4. add ACP-based health check
+
+## Phase 4 — MCP end-to-end validation
+
+1. persistent MCP config via `poe-code mcp`
+2. ACP session stdio MCP injection
+3. optional follow-up: widen spawn MCP types for HTTP MCP injection
+
+---
+
+## Risks / caveats
+
+## 1. ACP model override is not currently wired
+
+This is the biggest implementation risk, but it is contained and has a clean Goose-native solution via `_goose/session/provider/update`.
+
+## 2. YAML support is a shared-package change
+
+This is not risky conceptually, but it is a shared surface and should land first with focused tests.
+
+## 3. Spawn-time HTTP MCP is a generic follow-up
+
+Goose ACP supports HTTP MCP servers, but `packages/agent-spawn` still models spawn MCP input as stdio-only. If that matters for phase 1, widen the shared type. If not, ship persistent HTTP MCP first and stdio ACP injection first.
+
+## 4. Do not over-prune Goose config
+
+Unconfigure must not wipe unrelated Goose extensions, providers, or user-managed settings.
+
+---
+
+## Recommended delivery sequence
+
+### Commit 1
+
+- shared YAML support in `config-mutations`
+- tests
+
+### Commit 2
+
+- Goose MCP YAML config support in `agent-mcp-config`
+- tests
+
+### Commit 3
+
+- Goose agent definition + provider configure/install + skills mapping
+- tests
+
+### Commit 4
+
+- Goose ACP spawn config + ACP post-session provider/model hook
+- tests
+
+### Commit 5
+
+- spot tests + screenshots + final doc cleanup
+
+---
+
+## Future follow-up: Goose ACP plugin support
+
+Not required for initial Goose agent support, but worth noting:
+
+Goose ACP already exposes custom methods for extension/config management. That makes a future `poe-code` Goose plugin plausible without shelling into config files for every operation.
+
+Possible future direction:
+
+- a Goose-specific plugin/client that uses `_goose/config/extensions`, `_goose/extensions/add/remove`, and `_goose/session/provider/update`
+- use file mutation as the compatibility baseline, ACP extension methods as the richer path
+

--- a/docs/research/goose-agent-investigation.md
+++ b/docs/research/goose-agent-investigation.md
@@ -1,5 +1,7 @@
 # Goose Agent Investigation
 
+> Note: this investigation was the earlier research pass. The current implementation direction is captured in `docs/plans/goose-agent-acp.md`, which supersedes the earlier CLI/`stream-json` framing and treats Goose as an ACP-first integration.
+
 ## Scope
 
 This document investigates two separate questions:
@@ -14,21 +16,19 @@ Reference point for implementation expectations: [`docs/ADDING_AGENT.md`](../ADD
 ## Executive Summary
 
 - **Manual Goose + Poe setup is very feasible today.**
-- The two realistic configuration paths are:
-  1. **Goose built-in `openai` provider** pointed at the Poe OpenAI-compatible API
-  2. **A Goose custom provider** (`engine: "openai"`) pointed at Poe
-- For **real user setup**, the **custom provider path is the cleanest recommendation** because it gives Poe its own provider identity inside Goose instead of overloading the generic OpenAI provider.
-- For **`poe-code` first-class support**, Goose is **materially more complex** than the currently supported agents because its state is split across:
-  - `config.yaml`
-  - optional `custom_providers/*.json`
-  - keyring or `secrets.yaml`
-  - YAML `extensions` for MCP
-- The biggest `poe-code` integration gaps are:
+- The cleanest provider path is a **Goose custom provider** (`engine: "openai"`) pointed at Poe.
+- For **`poe-code` first-class support**, Goose should be treated as a **normal ACP-capable integration**, not as an exceptional case.
+- The real work is mostly shared/config work:
   - **YAML config mutation support**
-  - **secret storage handling** (keyring vs `secrets.yaml`)
-  - deciding whether Goose should be configured via **built-in OpenAI** or a **Goose custom provider**
-  - determining whether Goose’s `stream-json` can use the existing native adapter or needs a **Goose-specific adapter**
-- **Recommendation:** if Goose is added to `poe-code`, use the **custom provider strategy**, start with **configure + install + test + spawn (CLI)**, and treat **unconfigure/MCP config/skills** as follow-up work.
+  - Goose `extensions:` mapping for **MCP**
+  - file-based secrets fallback via `secrets.yaml`
+  - skill directory wiring plus explicit **Summon** enablement
+- The correct spawn strategy is **ACP-first** via `goose acp`, not CLI `stream-json`.
+- **Recommendation:** implement Goose in `poe-code` through:
+  1. custom provider configuration
+  2. YAML config support
+  3. MCP + skills support
+  4. ACP spawn
 
 ---
 
@@ -563,4 +563,3 @@ That choice is cleaner for:
 - `crates/goose/src/agents/platform_extensions/skills.rs`
 - `download_cli.sh`
 - `CONTRIBUTING.md`
-

--- a/e2e/goose.test.ts
+++ b/e2e/goose.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { useContainer } from '@poe-code/e2e-docker-test-runner';
+import { DEFAULT_GOOSE_MODEL } from '../src/cli/constants.js';
+
+describe('goose', () => {
+  const container = useContainer({ testName: 'goose' });
+
+  it('install, configure and test', async () => {
+    const installResult = await container.exec('poe-code install goose');
+    expect(installResult).toHaveExitCode(0);
+
+    const configureResult = await container.exec('poe-code configure goose --yes');
+    expect(configureResult).toHaveExitCode(0);
+
+    await expect(container).toHaveFile('/home/poe/.config/goose/config.yaml');
+    const config = parseYaml(
+      await container.readFile('/home/poe/.config/goose/config.yaml')
+    ) as Record<string, unknown>;
+    expect(config.GOOSE_PROVIDER).toBe('custom_poe');
+    expect(config.GOOSE_MODEL).toBe(DEFAULT_GOOSE_MODEL);
+
+    await expect(container).toHaveFile(
+      '/home/poe/.config/goose/custom_providers/custom_poe.json'
+    );
+    const provider = JSON.parse(
+      await container.readFile('/home/poe/.config/goose/custom_providers/custom_poe.json')
+    ) as Record<string, unknown>;
+    expect(provider.name).toBe('custom_poe');
+    expect(provider.api_key_env).toBe('CUSTOM_POE_API_KEY');
+    expect(provider.base_url).toBe('https://api.poe.com/v1/chat/completions');
+    expect(provider.headers).toHaveProperty('Authorization');
+
+    await expect(container).toHaveFile('/home/poe/.config/goose/secrets.yaml');
+    const secrets = parseYaml(
+      await container.readFile('/home/poe/.config/goose/secrets.yaml')
+    ) as Record<string, unknown>;
+    expect(secrets.CUSTOM_POE_API_KEY).toBeTypeOf('string');
+
+    const testResult = await container.exec('env -u POE_API_KEY poe-code test goose');
+    expect(testResult).toSucceedWith('Tested Goose.');
+  });
+
+  it('test --isolated', async () => {
+    const installResult = await container.exec('poe-code install goose');
+    expect(installResult).toHaveExitCode(0);
+
+    const result = await container.exec('env -u POE_API_KEY poe-code test goose --isolated');
+    expect(result).toSucceedWith('Tested Goose.');
+
+    await expect(container).toHaveFile('/home/poe/.poe-code/goose/.config/goose/secrets.yaml');
+    const isolatedSecrets = parseYaml(
+      await container.readFile('/home/poe/.poe-code/goose/.config/goose/secrets.yaml')
+    ) as Record<string, unknown>;
+    expect(isolatedSecrets.CUSTOM_POE_API_KEY).toBeTypeOf('string');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5911,7 +5911,8 @@
       "dependencies": {
         "jsonc-parser": "^3.3.1",
         "mustache": "^4.2.0",
-        "smol-toml": "^1.3.0"
+        "smol-toml": "^1.3.0",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@types/mustache": "^4.2.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5852,7 +5852,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@poe-code/agent-defs": "*",
-        "@poe-code/config-mutations": "*"
+        "@poe-code/config-mutations": "*",
+        "yaml": "^2.8.3"
       }
     },
     "packages/agent-skill-config": {

--- a/packages/agent-defs/src/agent-defs.test.ts
+++ b/packages/agent-defs/src/agent-defs.test.ts
@@ -5,6 +5,7 @@ import {
   codexAgent,
   openCodeAgent,
   kimiAgent,
+  gooseAgent,
   allAgents,
   resolveAgentId,
   type AgentDefinition
@@ -16,7 +17,8 @@ const expectedAgents: AgentDefinition[] = [
   claudeDesktopAgent,
   codexAgent,
   openCodeAgent,
-  kimiAgent
+  kimiAgent,
+  gooseAgent
 ];
 
 const normalizeKey = (value: string): string => value.toLowerCase();
@@ -28,6 +30,7 @@ describe("agent-defs package", () => {
     expect(codexAgent).toBeDefined();
     expect(openCodeAgent).toBeDefined();
     expect(kimiAgent).toBeDefined();
+    expect(gooseAgent).toBeDefined();
   });
 
   it.each(expectedAgents)("$id has all required fields", (agent) => {
@@ -80,6 +83,7 @@ describe("agent-defs package", () => {
   it("resolves aliases case-insensitively", () => {
     expect(resolveAgentId("CLAUDE")).toBe("claude-code");
     expect(resolveAgentId("kimi-cli")).toBe("kimi");
+    expect(resolveAgentId("GOOSE")).toBe("goose");
   });
 
   it("returns undefined for unknown agents", () => {

--- a/packages/agent-defs/src/agents/goose.ts
+++ b/packages/agent-defs/src/agents/goose.ts
@@ -1,0 +1,16 @@
+import type { AgentDefinition } from "../types.js";
+
+export const gooseAgent: AgentDefinition = {
+  id: "goose",
+  name: "goose",
+  label: "Goose",
+  summary: "Block's open-source AI agent with ACP support.",
+  binaryName: "goose",
+  configPath: "~/.config/goose/config.yaml",
+  branding: {
+    colors: {
+      dark: "#FF6B35",
+      light: "#E85D26"
+    }
+  }
+};

--- a/packages/agent-defs/src/agents/index.ts
+++ b/packages/agent-defs/src/agents/index.ts
@@ -3,3 +3,4 @@ export { claudeDesktopAgent } from "./claude-desktop.js";
 export { codexAgent } from "./codex.js";
 export { openCodeAgent } from "./opencode.js";
 export { kimiAgent } from "./kimi.js";
+export { gooseAgent } from "./goose.js";

--- a/packages/agent-defs/src/index.ts
+++ b/packages/agent-defs/src/index.ts
@@ -5,7 +5,8 @@ export {
   claudeDesktopAgent,
   codexAgent,
   openCodeAgent,
-  kimiAgent
+  kimiAgent,
+  gooseAgent
 } from "./agents/index.js";
 export { allAgents, resolveAgentId } from "./registry.js";
 export { parseAgentSpecifier, formatAgentSpecifier } from "./specifier.js";

--- a/packages/agent-defs/src/registry.ts
+++ b/packages/agent-defs/src/registry.ts
@@ -4,7 +4,8 @@ import {
   claudeDesktopAgent,
   codexAgent,
   openCodeAgent,
-  kimiAgent
+  kimiAgent,
+  gooseAgent
 } from "./agents/index.js";
 
 export const allAgents: AgentDefinition[] = [
@@ -12,7 +13,8 @@ export const allAgents: AgentDefinition[] = [
   claudeDesktopAgent,
   codexAgent,
   openCodeAgent,
-  kimiAgent
+  kimiAgent,
+  gooseAgent
 ];
 
 const lookup = new Map<string, string>();

--- a/packages/agent-mcp-config/package.json
+++ b/packages/agent-mcp-config/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "@poe-code/agent-defs": "*",
-    "@poe-code/config-mutations": "*"
+    "@poe-code/config-mutations": "*",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/agent-mcp-config/src/agent-mcp-config.test.ts
+++ b/packages/agent-mcp-config/src/agent-mcp-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createMockFs } from "@poe-code/config-mutations/testing";
+import { parse as parseYaml } from "yaml";
 import {
   configure,
   unconfigure,
@@ -10,6 +11,7 @@ import { resolveAgentSupport, type AgentMcpConfig } from "./configs.js";
 import {
   standardShape,
   opencodeShape,
+  gooseShape,
   getShapeTransformer
 } from "./shapes.js";
 
@@ -263,6 +265,160 @@ describe("configure", () => {
     });
   });
 
+  describe("goose", () => {
+    it("merges MCP servers into an existing YAML config", async () => {
+      const fs = createMockFs(
+        {
+          "~/.config/goose/config.yaml": [
+            "extensions:",
+            "  existing:",
+            "    type: stdio",
+            "    cmd: uvx",
+            "    args:",
+            "      - existing-server",
+            "otherKey: value"
+          ].join("\n")
+        },
+        HOME_DIR
+      );
+      const server: McpServerEntry = {
+        name: "poe-code",
+        config: {
+          transport: "stdio",
+          command: "npx",
+          args: ["poe-code", "mcp"],
+          env: { API_KEY: "secret" }
+        }
+      };
+
+      await configure("goose", server, createOptions(fs));
+
+      const content = parseYaml(
+        fs.getContent("/home/test/.config/goose/config.yaml")!
+      );
+      expect(content).toEqual({
+        extensions: {
+          existing: {
+            type: "stdio",
+            cmd: "uvx",
+            args: ["existing-server"]
+          },
+          "poe-code": {
+            type: "stdio",
+            cmd: "npx",
+            args: ["poe-code", "mcp"],
+            envs: { API_KEY: "secret" }
+          }
+        },
+        otherKey: "value"
+      });
+    });
+
+    it("writes a new YAML config when none exists", async () => {
+      const fs = createMockFs({}, HOME_DIR);
+      const server: McpServerEntry = {
+        name: "poe-code",
+        config: { transport: "stdio", command: "npx" }
+      };
+
+      await configure("goose", server, createOptions(fs));
+
+      const rawContent = fs.getContent("/home/test/.config/goose/config.yaml");
+      expect(rawContent).toContain("extensions:");
+      expect(parseYaml(rawContent!)).toEqual({
+        extensions: {
+          "poe-code": {
+            type: "stdio",
+            cmd: "npx"
+          }
+        }
+      });
+    });
+
+    it("preserves existing entries when writing then reading back YAML", async () => {
+      const fs = createMockFs({}, HOME_DIR);
+
+      await configure(
+        "goose",
+        {
+          name: "first-server",
+          config: { transport: "stdio", command: "npx", args: ["first"] }
+        },
+        createOptions(fs)
+      );
+
+      await configure(
+        "goose",
+        {
+          name: "second-server",
+          config: {
+            transport: "stdio",
+            command: "uvx",
+            env: { TOKEN: "abc" }
+          }
+        },
+        createOptions(fs)
+      );
+
+      expect(
+        parseYaml(fs.getContent("/home/test/.config/goose/config.yaml")!)
+      ).toEqual({
+        extensions: {
+          "first-server": {
+            type: "stdio",
+            cmd: "npx",
+            args: ["first"]
+          },
+          "second-server": {
+            type: "stdio",
+            cmd: "uvx",
+            envs: { TOKEN: "abc" }
+          }
+        }
+      });
+    });
+
+    it("removes a Goose YAML entry when enabled is false", async () => {
+      const fs = createMockFs(
+        {
+          "~/.config/goose/config.yaml": [
+            "extensions:",
+            "  poe-code:",
+            "    type: stdio",
+            "    cmd: npx",
+            "  other:",
+            "    type: stdio",
+            "    cmd: uvx",
+            "theme: dark"
+          ].join("\n")
+        },
+        HOME_DIR
+      );
+
+      await configure(
+        "goose",
+        {
+          name: "poe-code",
+          config: { transport: "stdio", command: "npx" },
+          enabled: false
+        },
+        createOptions(fs)
+      );
+
+      expect(
+        parseYaml(fs.getContent("/home/test/.config/goose/config.yaml")!)
+      ).toEqual({
+        extensions: {
+          other: {
+            type: "stdio",
+            cmd: "uvx"
+          }
+        },
+        theme: "dark"
+      });
+    });
+  });
+
   describe("error handling", () => {
     it("throws UnsupportedAgentError for unknown agent", async () => {
       const fs = createMockFs({}, HOME_DIR);
@@ -364,6 +520,29 @@ command = "test"
     const content = fs.getContent("/home/test/.codex/config.toml")!;
     expect(content).not.toContain("poe-code");
     expect(content).toContain("[mcp_servers.other]");
+  });
+
+  it("removes MCP server from goose YAML", async () => {
+    const fs = createMockFs(
+      {
+        "~/.config/goose/config.yaml": [
+          "extensions:",
+          "  poe-code:",
+          "    type: stdio",
+          "    cmd: npx",
+          "otherKey: value"
+        ].join("\n")
+      },
+      HOME_DIR
+    );
+
+    await unconfigure("goose", "poe-code", createOptions(fs));
+
+    expect(
+      parseYaml(fs.getContent("/home/test/.config/goose/config.yaml")!)
+    ).toEqual({
+      otherKey: "value"
+    });
   });
 });
 
@@ -562,5 +741,57 @@ describe("getShapeTransformer", () => {
 
   it("returns opencodeShape for opencode", () => {
     expect(getShapeTransformer("opencode")).toBe(opencodeShape);
+  });
+
+  it("returns gooseShape for goose", () => {
+    expect(getShapeTransformer("goose")).toBe(gooseShape);
+  });
+});
+
+describe("gooseShape", () => {
+  it("transforms stdio server fields to Goose keys", () => {
+    const entry: McpServerEntry = {
+      name: "test",
+      config: {
+        transport: "stdio",
+        command: "npx",
+        args: ["server"],
+        env: { API_KEY: "secret" }
+      }
+    };
+
+    expect(gooseShape(entry)).toEqual({
+      type: "stdio",
+      cmd: "npx",
+      args: ["server"],
+      envs: { API_KEY: "secret" }
+    });
+  });
+
+  it("omits empty optional Goose fields", () => {
+    const entry: McpServerEntry = {
+      name: "test",
+      config: {
+        transport: "stdio",
+        command: "npx",
+        args: [],
+        env: {}
+      }
+    };
+
+    expect(gooseShape(entry)).toEqual({
+      type: "stdio",
+      cmd: "npx"
+    });
+  });
+
+  it("returns undefined for disabled Goose entries", () => {
+    const entry: McpServerEntry = {
+      name: "test",
+      config: { transport: "stdio", command: "npx" },
+      enabled: false
+    };
+
+    expect(gooseShape(entry)).toBeUndefined();
   });
 });

--- a/packages/agent-mcp-config/src/apply.ts
+++ b/packages/agent-mcp-config/src/apply.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import {
   runMutations,
   configMutation,
   fileMutation,
+  readFileIfExists,
   type ConfigObject
 } from "@poe-code/config-mutations";
 import type { McpServerEntry, ApplyOptions } from "./types.js";
@@ -44,6 +46,101 @@ function mergeServerMap(
   return { ...document, [configKey]: servers };
 }
 
+function expandHomePath(configPath: string, homeDir: string): string {
+  if (!configPath.startsWith("~")) {
+    return configPath;
+  }
+
+  if (configPath === "~") {
+    return homeDir;
+  }
+
+  if (configPath.startsWith("~/")) {
+    return path.join(homeDir, configPath.slice(2));
+  }
+
+  return path.join(homeDir, configPath.slice(1));
+}
+
+function parseYamlDocument(content: string): ConfigObject {
+  if (content.trim() === "") {
+    return {};
+  }
+
+  const parsed = parseYaml(content);
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+
+  if (!isConfigObject(parsed)) {
+    throw new Error("Expected YAML document to be an object.");
+  }
+
+  return parsed;
+}
+
+function serializeYamlDocument(document: ConfigObject): string {
+  const serialized = stringifyYaml(document);
+  return serialized.endsWith("\n") ? serialized : `${serialized}\n`;
+}
+
+async function readYamlConfig(
+  configPath: string,
+  options: ApplyOptions
+): Promise<ConfigObject> {
+  const absolutePath = expandHomePath(configPath, options.homeDir);
+  const existingContent = await readFileIfExists(options.fs, absolutePath);
+
+  if (existingContent === null) {
+    return {};
+  }
+
+  return parseYamlDocument(existingContent);
+}
+
+async function writeYamlConfig(
+  configPath: string,
+  document: ConfigObject,
+  options: ApplyOptions
+): Promise<void> {
+  if (options.dryRun) {
+    return;
+  }
+
+  const absolutePath = expandHomePath(configPath, options.homeDir);
+  const configDir = path.dirname(absolutePath);
+
+  await options.fs.mkdir(configDir, { recursive: true });
+  await options.fs.writeFile(absolutePath, serializeYamlDocument(document), {
+    encoding: "utf8"
+  });
+}
+
+function removeServer(
+  document: ConfigObject,
+  configKey: string,
+  serverName: string
+): { changed: boolean; content: ConfigObject } {
+  const servers = resolveServerMap(document, configKey);
+  if (!(serverName in servers)) {
+    return { changed: false, content: document };
+  }
+
+  const nextServers = { ...servers };
+  delete nextServers[serverName];
+
+  if (Object.keys(nextServers).length === 0) {
+    const nextDocument = { ...document };
+    delete nextDocument[configKey];
+    return { changed: true, content: nextDocument };
+  }
+
+  return {
+    changed: true,
+    content: mergeServerMap(document, configKey, nextServers)
+  };
+}
+
 export async function configure(
   agentId: string,
   server: McpServerEntry,
@@ -60,6 +157,18 @@ export async function configure(
 
   if (shaped === undefined) {
     await unconfigure(agentId, server.name, options);
+    return;
+  }
+
+  if (config.format === "yaml") {
+    const document = await readYamlConfig(configPath, options);
+    const servers = resolveServerMap(document, config.configKey);
+    const nextDocument = mergeServerMap(document, config.configKey, {
+      ...servers,
+      [server.name]: shaped as unknown as ConfigObject
+    });
+
+    await writeYamlConfig(configPath, nextDocument, options);
     return;
   }
 
@@ -110,6 +219,23 @@ export async function unconfigure(
 
   const config = getAgentConfig(agentId)!;
   const configPath = resolveConfigPath(config, options.platform);
+
+  if (config.format === "yaml") {
+    const document = await readYamlConfig(configPath, options);
+    const { changed, content } = removeServer(
+      document,
+      config.configKey,
+      serverName
+    );
+
+    if (!changed) {
+      return;
+    }
+
+    await writeYamlConfig(configPath, content, options);
+    return;
+  }
+
   await runMutations(
     [
       configMutation.prune({

--- a/packages/agent-mcp-config/src/configs.ts
+++ b/packages/agent-mcp-config/src/configs.ts
@@ -1,7 +1,7 @@
 import { resolveAgentId } from "@poe-code/agent-defs";
 import type { ShapeName } from "./shapes.js";
 
-export type ConfigFormat = "json" | "toml";
+export type ConfigFormat = "json" | "toml" | "yaml";
 export type Platform = "darwin" | "linux" | "win32";
 
 export interface AgentMcpConfig {
@@ -52,6 +52,12 @@ const agentMcpConfigs: Record<string, AgentMcpConfig> = {
     configKey: "mcpServers",
     format: "json",
     shape: "standard"
+  },
+  goose: {
+    configFile: "~/.config/goose/config.yaml",
+    configKey: "extensions",
+    format: "yaml",
+    shape: "goose"
   }
 };
 

--- a/packages/agent-mcp-config/src/shapes.ts
+++ b/packages/agent-mcp-config/src/shapes.ts
@@ -1,6 +1,6 @@
 import type { McpServerConfig, McpServerEntry } from "./types.js";
 
-export type ShapeName = "standard" | "opencode";
+export type ShapeName = "standard" | "opencode" | "goose";
 
 export interface StandardShapeOutput {
   command: string;
@@ -15,9 +15,25 @@ export interface OpencodeShapeOutput {
   enabled: boolean;
 }
 
+export interface GooseStdioShapeOutput {
+  type: "stdio";
+  cmd: string;
+  args?: string[];
+  envs?: Record<string, string>;
+}
+
+export interface GooseHttpShapeOutput {
+  type: "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type GooseShapeOutput = GooseStdioShapeOutput | GooseHttpShapeOutput;
+
 export type ShapeOutput =
   | StandardShapeOutput
-  | OpencodeShapeOutput;
+  | OpencodeShapeOutput
+  | GooseShapeOutput;
 
 export type ShapeTransformer = (
   entry: McpServerEntry
@@ -91,9 +107,46 @@ export function opencodeShape(entry: McpServerEntry): OpencodeShapeOutput {
   };
 }
 
+export function gooseShape(entry: McpServerEntry): GooseShapeOutput | undefined {
+  const enabled = entry.enabled !== false;
+
+  if (!enabled) {
+    return undefined;
+  }
+
+  if (entry.config.transport === "stdio") {
+    const result: GooseStdioShapeOutput = {
+      type: "stdio",
+      cmd: entry.config.command
+    };
+
+    if (entry.config.args && entry.config.args.length > 0) {
+      result.args = entry.config.args;
+    }
+
+    if (entry.config.env && Object.keys(entry.config.env).length > 0) {
+      result.envs = entry.config.env;
+    }
+
+    return result;
+  }
+
+  const result: GooseHttpShapeOutput = {
+    type: "http",
+    url: entry.config.url
+  };
+
+  if (entry.config.headers && Object.keys(entry.config.headers).length > 0) {
+    result.headers = entry.config.headers;
+  }
+
+  return result;
+}
+
 const shapeTransformers: Record<ShapeName, ShapeTransformer> = {
   standard: standardShape,
-  opencode: opencodeShape
+  opencode: opencodeShape,
+  goose: gooseShape
 };
 
 export function getShapeTransformer(shape: ShapeName): ShapeTransformer {

--- a/packages/agent-skill-config/src/agent-skill-config.test.ts
+++ b/packages/agent-skill-config/src/agent-skill-config.test.ts
@@ -9,14 +9,9 @@ import {
   getAgentConfig,
   resolveAgentSupport,
   resolveSkillDir,
-  supportedAgents,
+  supportedAgents
 } from "./configs.js";
-import {
-  configure,
-  installSkill,
-  unconfigure,
-  UnsupportedAgentError,
-} from "./apply.js";
+import { configure, installSkill, unconfigure, UnsupportedAgentError } from "./apply.js";
 import { loadTemplate, createTemplateLoader } from "./templates.js";
 
 function createMemFs(): { fs: FileSystem; vol: Volume } {
@@ -104,7 +99,7 @@ function extractBodyAfterFrontmatter(markdown: string): string {
 
 describe("supportedAgents", () => {
   it("includes supported agent ids", () => {
-    expect(supportedAgents).toEqual(["claude-code", "codex", "opencode"]);
+    expect(supportedAgents).toEqual(["claude-code", "codex", "opencode", "goose"]);
   });
 });
 
@@ -115,7 +110,7 @@ describe("resolveAgentSupport", () => {
     expect(result.id).toBe("claude-code");
     expect(result.config).toEqual({
       globalSkillDir: "~/.claude/skills",
-      localSkillDir: ".claude/skills",
+      localSkillDir: ".claude/skills"
     });
   });
 
@@ -123,6 +118,16 @@ describe("resolveAgentSupport", () => {
     const result = resolveAgentSupport("CLAUDE");
     expect(result.status).toBe("supported");
     expect(result.id).toBe("claude-code");
+  });
+
+  it("returns supported for goose", () => {
+    const result = resolveAgentSupport("goose");
+    expect(result.status).toBe("supported");
+    expect(result.id).toBe("goose");
+    expect(result.config).toEqual({
+      globalSkillDir: "~/.agents/skills",
+      localSkillDir: ".agents/skills"
+    });
   });
 
   it("returns unknown when no agent matches", () => {
@@ -135,7 +140,7 @@ describe("getAgentConfig", () => {
   it("returns config for supported agent id", () => {
     expect(getAgentConfig("codex")).toEqual({
       globalSkillDir: "~/.codex/skills",
-      localSkillDir: ".codex/skills",
+      localSkillDir: ".codex/skills"
     });
   });
 
@@ -160,6 +165,17 @@ describe("resolveSkillDir", () => {
 
     const result = resolveSkillDir(config!, "global", "/repo");
     expect(result).toBe(path.resolve(path.join(os.homedir(), ".config/opencode/skills")));
+  });
+
+  it("resolves goose directories using .agents conventions", () => {
+    const config = getAgentConfig("goose");
+    expect(config).toBeDefined();
+
+    const cwd = "/repo";
+    expect(resolveSkillDir(config!, "local", cwd)).toBe(path.resolve(cwd, ".agents/skills"));
+    expect(resolveSkillDir(config!, "global", cwd)).toBe(
+      path.resolve(path.join(os.homedir(), ".agents/skills"))
+    );
   });
 });
 
@@ -202,7 +218,7 @@ describe("configure", () => {
 
     await expect(memFs.stat(`${homeDir}/.claude/skills`)).resolves.toBeDefined();
     const content = await memFs.readFile(`${homeDir}/.claude/skills/poe-generate.md`, {
-      encoding: "utf8",
+      encoding: "utf8"
     });
     expect(content).toContain("name: poe-generate");
     expect(content).toContain("# poe-code generate");
@@ -213,10 +229,28 @@ describe("configure", () => {
 
     await expect(memFs.stat(`${cwd}/.claude/skills`)).resolves.toBeDefined();
     const content = await memFs.readFile(`${cwd}/.claude/skills/poe-generate.md`, {
-      encoding: "utf8",
+      encoding: "utf8"
     });
     expect(content).toContain("name: poe-generate");
     expect(content).toContain("# poe-code generate");
+  });
+
+  it("creates goose skill directories using the shared .agents convention", async () => {
+    await configure("goose", { fs: memFs, homeDir, cwd });
+    await configure("goose", { fs: memFs, homeDir, cwd, scope: "local" });
+
+    await expect(memFs.stat(`${homeDir}/.agents/skills`)).resolves.toBeDefined();
+    await expect(memFs.stat(`${cwd}/.agents/skills`)).resolves.toBeDefined();
+
+    const globalContent = await memFs.readFile(`${homeDir}/.agents/skills/poe-generate.md`, {
+      encoding: "utf8"
+    });
+    const localContent = await memFs.readFile(`${cwd}/.agents/skills/poe-generate.md`, {
+      encoding: "utf8"
+    });
+
+    expect(globalContent).toContain("name: poe-generate");
+    expect(localContent).toContain("name: poe-generate");
   });
 });
 
@@ -233,9 +267,9 @@ describe("unconfigure", () => {
   });
 
   it("throws UnsupportedAgentError for unknown agent", async () => {
-    await expect(
-      unconfigure("unknown", { fs: memFs, homeDir, cwd })
-    ).rejects.toBeInstanceOf(UnsupportedAgentError);
+    await expect(unconfigure("unknown", { fs: memFs, homeDir, cwd })).rejects.toBeInstanceOf(
+      UnsupportedAgentError
+    );
   });
 
   it("removes global skill directory by default when force is set", async () => {
@@ -298,11 +332,11 @@ describe("installSkill", () => {
 
     expect(result).toEqual({
       skillPath: "~/.claude/skills/terminal-pilot/SKILL.md",
-      displayPath: ".claude/skills/terminal-pilot/SKILL.md",
+      displayPath: ".claude/skills/terminal-pilot/SKILL.md"
     });
 
     const content = await memFs.readFile(`${cwd}/.claude/skills/terminal-pilot/SKILL.md`, {
-      encoding: "utf8",
+      encoding: "utf8"
     });
     expect(content).toContain("name: terminal-pilot");
     expect(content).toContain("# Terminal Pilot");
@@ -318,6 +352,25 @@ describe("installSkill", () => {
         { fs: memFs, cwd, homeDir, scope: "local" }
       )
     ).rejects.toBeInstanceOf(UnsupportedAgentError);
+  });
+
+  it("installs a goose skill into the shared local .agents directory", async () => {
+    const result = await installSkill(
+      "goose",
+      { name: "terminal-pilot", content: "# Goose skill" },
+      { fs: memFs, cwd, homeDir, scope: "local" }
+    );
+
+    expect(result).toEqual({
+      skillPath: "~/.agents/skills/terminal-pilot/SKILL.md",
+      displayPath: ".agents/skills/terminal-pilot/SKILL.md"
+    });
+
+    await expect(
+      memFs.readFile(`${cwd}/.agents/skills/terminal-pilot/SKILL.md`, {
+        encoding: "utf8"
+      })
+    ).resolves.toBe("# Goose skill");
   });
 });
 
@@ -357,7 +410,7 @@ describe("bundled skill template: poe-generate.md", () => {
     const frontmatter = parseYamlFrontmatter(template);
     expect(frontmatter).toMatchObject({
       name: "poe-generate",
-      description: "Poe code generation skill",
+      description: "Poe code generation skill"
     });
 
     const body = extractBodyAfterFrontmatter(template);
@@ -366,9 +419,9 @@ describe("bundled skill template: poe-generate.md", () => {
   });
 
   it("fails validation when frontmatter is malformed", () => {
-    expect(() =>
-      parseYamlFrontmatter(["---", "name: poe-generate"].join("\n"))
-    ).toThrow("Missing YAML frontmatter end delimiter");
+    expect(() => parseYamlFrontmatter(["---", "name: poe-generate"].join("\n"))).toThrow(
+      "Missing YAML frontmatter end delimiter"
+    );
   });
 });
 
@@ -382,7 +435,7 @@ describe("bundled skill template: terminal-pilot.md", () => {
     const frontmatter = parseYamlFrontmatter(template);
     expect(frontmatter).toMatchObject({
       name: "terminal-pilot",
-      description: "Terminal automation skill using the terminal-pilot CLI",
+      description: "Terminal automation skill using the terminal-pilot CLI"
     });
 
     const body = extractBodyAfterFrontmatter(template);

--- a/packages/agent-skill-config/src/configs.ts
+++ b/packages/agent-skill-config/src/configs.ts
@@ -21,6 +21,10 @@ const agentSkillConfigs: Record<string, AgentSkillConfig> = {
   opencode: {
     globalSkillDir: "~/.config/opencode/skills",
     localSkillDir: ".opencode/skills"
+  },
+  goose: {
+    globalSkillDir: "~/.agents/skills",
+    localSkillDir: ".agents/skills"
   }
 };
 
@@ -84,15 +88,10 @@ function expandHome(targetPath: string): string {
   return remainder.length === 0 ? os.homedir() : path.join(os.homedir(), remainder);
 }
 
-export function resolveSkillDir(
-  config: AgentSkillConfig,
-  scope: SkillScope,
-  cwd: string
-): string {
+export function resolveSkillDir(config: AgentSkillConfig, scope: SkillScope, cwd: string): string {
   if (scope === "global") {
     return path.resolve(expandHome(config.globalSkillDir));
   }
 
   return path.resolve(cwd, config.localSkillDir);
 }
-

--- a/packages/agent-spawn/src/acp/spawn.ts
+++ b/packages/agent-spawn/src/acp/spawn.ts
@@ -5,7 +5,7 @@ import { readLines } from "./line-reader.js";
 import { resolveConfig } from "../configs/resolve-config.js";
 import { getMcpArgs, getMcpEnv } from "../mcp-args.js";
 import { stripModelNamespace } from "../model-utils.js";
-import type { SpawnOptions, SpawnResult } from "../types.js";
+import type { CliSpawnConfig, SpawnOptions, SpawnResult } from "../types.js";
 
 function createAbortError(): Error {
   const error = new Error("Agent spawn aborted");
@@ -34,6 +34,19 @@ function isAcpEvent(value: unknown): value is AcpEvent {
   return !!value && typeof value === "object" && "event" in value;
 }
 
+function getDefaultArgsPosition(config: CliSpawnConfig): "beforePrompt" | "afterPrompt" {
+  return config.defaultArgsPosition ?? "afterPrompt";
+}
+
+function getMcpArgsPosition(
+  config: CliSpawnConfig
+): "beforeCommand" | "beforePrompt" | "afterCommand" {
+  if (config.mcpArgsPosition) {
+    return config.mcpArgsPosition;
+  }
+  return config.mcpArgsBeforeCommand ? "beforeCommand" : "afterCommand";
+}
+
 export function spawnStreaming(options: SpawnStreamingOptions): SpawnStreamingResult {
   if (options.signal?.aborted) {
     throw createAbortError();
@@ -55,9 +68,19 @@ export function spawnStreaming(options: SpawnStreamingOptions): SpawnStreamingRe
 
   const mcpArgs = getMcpArgs(spawnConfig, options.mcpServers);
   const mcpEnvVars = getMcpEnv(spawnConfig, options.mcpServers);
+  const defaultArgsPosition = getDefaultArgsPosition(spawnConfig);
+  const mcpArgsPosition = getMcpArgsPosition(spawnConfig);
   const args: string[] = [];
 
-  if (spawnConfig.mcpArgsBeforeCommand) {
+  if (mcpArgsPosition === "beforeCommand") {
+    args.push(...mcpArgs);
+  }
+
+  if (defaultArgsPosition === "beforePrompt") {
+    args.push(...spawnConfig.defaultArgs);
+  }
+
+  if (mcpArgsPosition === "beforePrompt") {
     args.push(...mcpArgs);
   }
 
@@ -76,9 +99,11 @@ export function spawnStreaming(options: SpawnStreamingOptions): SpawnStreamingRe
     args.push(spawnConfig.modelFlag, model);
   }
 
-  args.push(...spawnConfig.defaultArgs);
+  if (defaultArgsPosition === "afterPrompt") {
+    args.push(...spawnConfig.defaultArgs);
+  }
 
-  if (!spawnConfig.mcpArgsBeforeCommand) {
+  if (mcpArgsPosition === "afterCommand") {
     args.push(...mcpArgs);
   }
 

--- a/packages/agent-spawn/src/agent-spawn.test.ts
+++ b/packages/agent-spawn/src/agent-spawn.test.ts
@@ -6,6 +6,7 @@ import { claudeCodeSpawnConfig } from "./configs/claude-code.js";
 import { codexSpawnConfig } from "./configs/codex.js";
 import { openCodeSpawnConfig } from "./configs/opencode.js";
 import { kimiSpawnConfig } from "./configs/kimi.js";
+import { gooseSpawnConfig } from "./configs/goose.js";
 import * as agentSpawnApi from "@poe-code/agent-spawn";
 import { buildSpawnArgs } from "./spawn.js";
 import { getMcpArgs } from "./mcp-args.js";
@@ -293,6 +294,23 @@ describe("buildSpawnArgs", () => {
     ]);
   });
 
+  it("builds goose args with the run subcommand before prompt and model flags", () => {
+    const result = buildSpawnArgs("goose", {
+      prompt: "hello",
+      model: "openai/gpt-5.4"
+    });
+
+    expect(result.binaryName).toBe("goose");
+    expect(result.args).toEqual([
+      ...gooseSpawnConfig.defaultArgs,
+      gooseSpawnConfig.promptFlag,
+      "hello",
+      gooseSpawnConfig.modelFlag!,
+      "openai/gpt-5.4",
+      ...gooseSpawnConfig.modes.yolo
+    ]);
+  });
+
   it("builds stdin args for claude-code when useStdin is true", () => {
     const result = buildSpawnArgs("claude-code", { prompt: "test", useStdin: true });
 
@@ -416,6 +434,27 @@ describe("buildSpawnArgs", () => {
       }
     });
     expect(result.args.slice(mcpIndex + 2)).toEqual([...kimiSpawnConfig.modes.yolo]);
+  });
+
+  it("adds goose MCP config as --with-extension args before the prompt flag", () => {
+    const result = buildSpawnArgs("goose", {
+      prompt: "hello",
+      mcpServers: {
+        test: {
+          command: "uvx",
+          args: ["mcp-server-test", "--port", "3000"]
+        }
+      }
+    });
+
+    expect(result.args).toEqual([
+      ...gooseSpawnConfig.defaultArgs,
+      "--with-extension",
+      "uvx mcp-server-test --port 3000",
+      gooseSpawnConfig.promptFlag,
+      "hello",
+      ...gooseSpawnConfig.modes.yolo
+    ]);
   });
 
   it("throws a clear error when MCP config is passed to unsupported agents", () => {

--- a/packages/agent-spawn/src/configs/configs.test.ts
+++ b/packages/agent-spawn/src/configs/configs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  getAcpSpawnConfig,
   getSpawnConfig,
   listMcpSupportedAgents,
   supportsMcpAtSpawn
@@ -8,6 +9,8 @@ import { codexSpawnConfig } from "./codex.js";
 import { claudeCodeSpawnConfig } from "./claude-code.js";
 import { openCodeSpawnConfig } from "./opencode.js";
 import { kimiSpawnConfig } from "./kimi.js";
+import { gooseSpawnConfig, gooseAcpSpawnConfig } from "./goose.js";
+import { serializeGooseMcpArgs } from "./mcp.js";
 
 describe("configs/getSpawnConfig", () => {
   it("returns undefined for claude-desktop", () => {
@@ -19,6 +22,7 @@ describe("configs/mcp support", () => {
   it("reports spawn-time MCP support for configured agents", () => {
     expect(supportsMcpAtSpawn("claude-code")).toBe(true);
     expect(supportsMcpAtSpawn("codex")).toBe(true);
+    expect(supportsMcpAtSpawn("goose")).toBe(true);
     expect(supportsMcpAtSpawn("kimi")).toBe(true);
     expect(supportsMcpAtSpawn("opencode")).toBe(true);
   });
@@ -29,7 +33,19 @@ describe("configs/mcp support", () => {
   });
 
   it("lists MCP-capable agents", () => {
-    expect(listMcpSupportedAgents()).toEqual(["claude-code", "codex", "opencode", "kimi"]);
+    expect(listMcpSupportedAgents()).toEqual([
+      "claude-code",
+      "codex",
+      "opencode",
+      "kimi",
+      "goose"
+    ]);
+  });
+});
+
+describe("configs/getAcpSpawnConfig", () => {
+  it("returns the registered ACP config for goose", () => {
+    expect(getAcpSpawnConfig("goose")).toEqual(gooseAcpSpawnConfig);
   });
 });
 
@@ -67,6 +83,36 @@ describe("resumeCommand", () => {
       threadId,
       "--work-dir",
       cwd
+    ]);
+  });
+
+  it("goose returns run --resume with a continue prompt", () => {
+    expect(gooseSpawnConfig.resumeCommand!(threadId, cwd)).toEqual([
+      "run",
+      "--resume",
+      "--text",
+      "continue"
+    ]);
+  });
+});
+
+describe("serializeGooseMcpArgs", () => {
+  it("serializes runtime MCP servers as repeated --with-extension args", () => {
+    expect(
+      serializeGooseMcpArgs({
+        alpha: {
+          command: "uvx",
+          args: ["mcp-server-alpha", "--port", "3000"]
+        },
+        beta: {
+          command: "node"
+        }
+      })
+    ).toEqual([
+      "--with-extension",
+      "uvx mcp-server-alpha --port 3000",
+      "--with-extension",
+      "node"
     ]);
   });
 });

--- a/packages/agent-spawn/src/configs/goose.ts
+++ b/packages/agent-spawn/src/configs/goose.ts
@@ -1,0 +1,36 @@
+import type { AcpSpawnConfig, CliSpawnConfig } from "../types.js";
+import { serializeGooseMcpArgs } from "./mcp.js";
+
+export const gooseSpawnConfig: CliSpawnConfig = {
+  kind: "cli",
+  agentId: "goose",
+  adapter: "native",
+  promptFlag: "--text",
+  modelFlag: "--model",
+  modelStripProviderPrefix: false,
+  defaultArgs: ["run", "--output-format", "stream-json"],
+  defaultArgsPosition: "beforePrompt",
+  mcpArgs: serializeGooseMcpArgs,
+  mcpArgsPosition: "beforePrompt",
+  modes: {
+    yolo: [],
+    edit: [],
+    read: []
+  },
+  stdinMode: {
+    omitPrompt: true,
+    extraArgs: ["--instructions", "-"]
+  },
+  interactive: {
+    defaultArgs: ["session"],
+    defaultArgsPosition: "beforePrompt"
+  },
+  resumeCommand: () => ["run", "--resume", "--text", "continue"]
+};
+
+export const gooseAcpSpawnConfig: AcpSpawnConfig = {
+  kind: "acp",
+  agentId: "goose",
+  acpArgs: ["acp"],
+  skipAuth: true
+};

--- a/packages/agent-spawn/src/configs/index.ts
+++ b/packages/agent-spawn/src/configs/index.ts
@@ -4,14 +4,16 @@ import { claudeCodeSpawnConfig } from "./claude-code.js";
 import { codexSpawnConfig } from "./codex.js";
 import { openCodeSpawnConfig, openCodeAcpSpawnConfig } from "./opencode.js";
 import { kimiSpawnConfig, kimiAcpSpawnConfig } from "./kimi.js";
+import { gooseSpawnConfig, gooseAcpSpawnConfig } from "./goose.js";
 
 // ACP adapter support (spawn streaming):
-// - Supported (has `adapter`): claude-code, codex, opencode, kimi
+// - Supported (has `adapter`): claude-code, codex, opencode, kimi, goose
 export const allSpawnConfigs: readonly SpawnConfig[] = [
   claudeCodeSpawnConfig,
   codexSpawnConfig,
   openCodeSpawnConfig,
-  kimiSpawnConfig
+  kimiSpawnConfig,
+  gooseSpawnConfig
 ];
 
 const lookup = new Map<string, SpawnConfig>();
@@ -23,6 +25,7 @@ for (const config of allSpawnConfigs) {
 const acpLookup = new Map<string, AcpSpawnConfig>();
 acpLookup.set(openCodeAcpSpawnConfig.agentId, openCodeAcpSpawnConfig);
 acpLookup.set(kimiAcpSpawnConfig.agentId, kimiAcpSpawnConfig);
+acpLookup.set(gooseAcpSpawnConfig.agentId, gooseAcpSpawnConfig);
 
 export function getSpawnConfig(input: string): SpawnConfig | undefined {
   const resolvedId = resolveAgentId(input);

--- a/packages/agent-spawn/src/configs/mcp.ts
+++ b/packages/agent-spawn/src/configs/mcp.ts
@@ -81,3 +81,10 @@ export function serializeCodexMcpArgs(servers: McpSpawnConfig): string[] {
 
   return args;
 }
+
+export function serializeGooseMcpArgs(servers: McpSpawnConfig): string[] {
+  return Object.values(servers).flatMap((server) => [
+    "--with-extension",
+    [server.command, ...(server.args ?? [])].join(" ")
+  ]);
+}

--- a/packages/agent-spawn/src/spawn-interactive.test.ts
+++ b/packages/agent-spawn/src/spawn-interactive.test.ts
@@ -6,6 +6,7 @@ import { claudeCodeSpawnConfig } from "./configs/claude-code.js";
 import { codexSpawnConfig } from "./configs/codex.js";
 import { openCodeSpawnConfig } from "./configs/opencode.js";
 import { kimiSpawnConfig } from "./configs/kimi.js";
+import { gooseSpawnConfig } from "./configs/goose.js";
 import { spawnInteractive } from "./spawn-interactive.js";
 import { getMcpArgs } from "./mcp-args.js";
 import type { CliSpawnConfig } from "./types.js";
@@ -134,6 +135,22 @@ describe("spawnInteractive", () => {
       "test prompt",
       ...kimiSpawnConfig.interactive!.defaultArgs,
       ...kimiSpawnConfig.modes.yolo
+    ]);
+  });
+
+  it("builds goose interactive args with the session subcommand before the prompt", async () => {
+    const spawnMock = vi
+      .mocked(spawnChildProcess)
+      .mockReturnValue(createMockInheritProcess(0));
+
+    await spawnInteractive("goose", { prompt: "test prompt" });
+
+    const [command, args] = spawnMock.mock.calls[0];
+    expect(command).toBe("goose");
+    expect(args).toEqual([
+      ...gooseSpawnConfig.interactive!.defaultArgs,
+      "test prompt",
+      ...gooseSpawnConfig.modes.yolo
     ]);
   });
 

--- a/packages/agent-spawn/src/spawn-interactive.ts
+++ b/packages/agent-spawn/src/spawn-interactive.ts
@@ -31,6 +31,10 @@ export async function spawnInteractive(
 
   const args: string[] = [];
 
+  if (interactive.defaultArgsPosition === "beforePrompt") {
+    args.push(...interactive.defaultArgs);
+  }
+
   if (options.prompt) {
     if (interactive.promptFlag) {
       args.push(interactive.promptFlag, options.prompt);
@@ -47,7 +51,9 @@ export async function spawnInteractive(
     args.push(spawnConfig.modelFlag, model);
   }
 
-  args.push(...interactive.defaultArgs);
+  if (interactive.defaultArgsPosition !== "beforePrompt") {
+    args.push(...interactive.defaultArgs);
+  }
   args.push(...getMcpArgs(spawnConfig, options.mcpServers));
 
   const mode = options.mode ?? "yolo";

--- a/packages/agent-spawn/src/spawn.ts
+++ b/packages/agent-spawn/src/spawn.ts
@@ -66,16 +66,39 @@ function resolveCliConfig(agentId: string) {
   };
 }
 
+function getDefaultArgsPosition(config: CliSpawnConfig): "beforePrompt" | "afterPrompt" {
+  return config.defaultArgsPosition ?? "afterPrompt";
+}
+
+function getMcpArgsPosition(
+  config: CliSpawnConfig
+): "beforeCommand" | "beforePrompt" | "afterCommand" {
+  if (config.mcpArgsPosition) {
+    return config.mcpArgsPosition;
+  }
+  return config.mcpArgsBeforeCommand ? "beforeCommand" : "afterCommand";
+}
+
 function buildCliArgs(
   config: CliSpawnConfig,
   options: BuildSpawnArgsOptions,
   stdinMode?: StdinMode
 ): string[] {
   const mcpArgs = getMcpArgs(config, options.mcpServers);
+  const defaultArgsPosition = getDefaultArgsPosition(config);
+  const mcpArgsPosition = getMcpArgsPosition(config);
 
   const args: string[] = [];
 
-  if (config.mcpArgsBeforeCommand) {
+  if (mcpArgsPosition === "beforeCommand") {
+    args.push(...mcpArgs);
+  }
+
+  if (defaultArgsPosition === "beforePrompt") {
+    args.push(...config.defaultArgs);
+  }
+
+  if (mcpArgsPosition === "beforePrompt") {
     args.push(...mcpArgs);
   }
 
@@ -97,9 +120,11 @@ function buildCliArgs(
     args.push(config.modelFlag, model);
   }
 
-  args.push(...config.defaultArgs);
+  if (defaultArgsPosition === "afterPrompt") {
+    args.push(...config.defaultArgs);
+  }
 
-  if (!config.mcpArgsBeforeCommand) {
+  if (mcpArgsPosition === "afterCommand") {
     args.push(...mcpArgs);
   }
 

--- a/packages/agent-spawn/src/types.ts
+++ b/packages/agent-spawn/src/types.ts
@@ -64,6 +64,7 @@ export interface StdinMode {
 
 export interface InteractiveSpawnConfig {
   defaultArgs: string[];
+  defaultArgsPosition?: "beforePrompt" | "afterPrompt";
   promptFlag?: string;
 }
 
@@ -73,6 +74,7 @@ export interface CliSpawnConfig {
   adapter: AdapterType;
   promptFlag: string;
   defaultArgs: string[];
+  defaultArgsPosition?: "beforePrompt" | "afterPrompt";
   modes: Record<SpawnMode, string[]>;
   stdinMode?: StdinMode;
   modelFlag?: string;
@@ -99,6 +101,15 @@ export interface CliSpawnConfig {
    */
   mcpEnv?: (servers: McpSpawnConfig) => Record<string, string>;
   /**
+   * Controls where serialized MCP args are inserted relative to the command.
+   *
+   * - "beforeCommand": before the prompt/subcommand section (e.g. `codex -c ... exec "prompt"`)
+   * - "beforePrompt": after `defaultArgs` but before the prompt/model section
+   * - "afterCommand": after `defaultArgs` (default)
+   */
+  mcpArgsPosition?: "beforeCommand" | "beforePrompt" | "afterCommand";
+  /**
+   * @deprecated Prefer `mcpArgsPosition`.
    * When true, MCP args are placed before the subcommand (e.g. `codex -c ... exec "prompt"`).
    * When false/undefined, they are placed after defaultArgs (e.g. `claude -p "prompt" --mcp-servers ...`).
    */

--- a/packages/config-mutations/package.json
+++ b/packages/config-mutations/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "jsonc-parser": "^3.3.1",
     "mustache": "^4.2.0",
-    "smol-toml": "^1.3.0"
+    "smol-toml": "^1.3.0",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/mustache": "^4.2.6"

--- a/packages/config-mutations/src/config-mutations.test.ts
+++ b/packages/config-mutations/src/config-mutations.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Volume, createFsFromVolume } from "memfs";
 import type { FileSystem } from "./types.js";
-import { getConfigFormat, detectFormat, jsonFormat, tomlFormat } from "./formats/index.js";
+import {
+  getConfigFormat,
+  detectFormat,
+  jsonFormat,
+  tomlFormat,
+  yamlFormat
+} from "./formats/index.js";
 import {
   detectIndent,
   modifyAtPath,
@@ -17,7 +23,9 @@ import {
   parseToml,
   serializeToml,
   parseJson,
-  serializeJson
+  serializeJson,
+  parseYaml,
+  serializeYaml
 } from "./testing/format-utils.js";
 import { isConfigObject } from "./types.js";
 
@@ -45,6 +53,7 @@ describe("getConfigFormat", () => {
     it("is case-insensitive for extensions", () => {
       expect(getConfigFormat("file.JSON")).toBe(jsonFormat);
       expect(getConfigFormat("file.TOML")).toBe(tomlFormat);
+      expect(getConfigFormat("file.YAML")).toBe(yamlFormat);
     });
 
     it("throws for unsupported extension", () => {
@@ -66,6 +75,11 @@ describe("getConfigFormat", () => {
       const format = getConfigFormat("toml");
       expect(format).toBe(tomlFormat);
     });
+
+    it("returns YAML format for 'yaml'", () => {
+      const format = getConfigFormat("yaml");
+      expect(format).toBe(yamlFormat);
+    });
   });
 });
 
@@ -78,8 +92,12 @@ describe("detectFormat", () => {
     expect(detectFormat("file.toml")).toBe("toml");
   });
 
+  it("detects YAML from .yaml and .yml extensions", () => {
+    expect(detectFormat("file.yaml")).toBe("yaml");
+    expect(detectFormat("file.yml")).toBe("yaml");
+  });
+
   it("returns undefined for unknown extensions", () => {
-    expect(detectFormat("file.yaml")).toBeUndefined();
     expect(detectFormat("file")).toBeUndefined();
   });
 });
@@ -531,6 +549,50 @@ describe("tomlFormat", () => {
   });
 });
 
+describe("yamlFormat", () => {
+  describe("parse", () => {
+    it("parses valid YAML", () => {
+      expect(yamlFormat.parse("key: value\n")).toEqual({ key: "value" });
+    });
+
+    it("returns empty object for empty string", () => {
+      expect(yamlFormat.parse("")).toEqual({});
+    });
+
+    it("throws for YAML arrays", () => {
+      expect(() => yamlFormat.parse("- one\n- two\n")).toThrow("Expected YAML object");
+    });
+  });
+
+  describe("serialize", () => {
+    it("serializes YAML with trailing newline", () => {
+      expect(yamlFormat.serialize({ key: "value" })).toBe("key: value\n");
+    });
+  });
+
+  describe("merge", () => {
+    it("deep merges nested objects", () => {
+      expect(
+        yamlFormat.merge(
+          { nested: { a: 1, b: 2 } },
+          { nested: { b: 3, c: 4 } }
+        )
+      ).toEqual({ nested: { a: 1, b: 3, c: 4 } });
+    });
+  });
+
+  describe("prune", () => {
+    it("removes keys matching shape", () => {
+      const { changed, result } = yamlFormat.prune(
+        { keep: true, remove: true },
+        { remove: {} }
+      );
+      expect(changed).toBe(true);
+      expect(result).toEqual({ keep: true });
+    });
+  });
+});
+
 // --- execution/remove-directory.test.ts ---
 
 describe("fileMutation.removeDirectory", () => {
@@ -649,6 +711,24 @@ describe("runMutations", () => {
 
       expect(fs.files[`${homeDir}/.config/settings.toml`]).toContain('key = "value"');
     });
+
+    it("creates new YAML file", async () => {
+      const fs = createMockFs({}, homeDir);
+      await fs.mkdir(`${homeDir}/.config`, { recursive: true });
+
+      await runMutations(
+        [
+          configMutation.merge({
+            target: "~/.config/settings.yaml",
+            format: "yaml",
+            value: { key: "value" }
+          })
+        ],
+        { fs, homeDir }
+      );
+
+      expect(fs.files[`${homeDir}/.config/settings.yaml`]).toBe("key: value\n");
+    });
   });
 
   describe("configMutation.prune", () => {
@@ -718,6 +798,26 @@ describe("runMutations", () => {
 
       const content = JSON.parse(fs.files[`${homeDir}/.config.json`]);
       expect(content).toEqual({ owner: "me" });
+    });
+
+    it("prunes YAML files", async () => {
+      const fs = createMockFs({
+        "~/.config.yaml": "owner: me\nkey: value\n"
+      }, homeDir);
+
+      await runMutations(
+        [
+          configMutation.prune({
+            target: "~/.config.yaml",
+            format: "yaml",
+            shape: { key: {} },
+            onlyIf: (doc) => doc.owner === "me"
+          })
+        ],
+        { fs, homeDir }
+      );
+
+      expect(fs.files[`${homeDir}/.config.yaml`]).toBe("owner: me\n");
     });
   });
 
@@ -910,6 +1010,14 @@ describe("format utils", () => {
 
   it("serializes JSON with 2-space indentation", () => {
     expect(serializeJson({ key: "value" })).toBe('{\n  "key": "value"\n}\n');
+  });
+
+  it("parses YAML into a config object", () => {
+    expect(parseYaml("key: value\n")).toEqual({ key: "value" });
+  });
+
+  it("serializes YAML with trailing newline", () => {
+    expect(serializeYaml({ key: "value" })).toBe("key: value\n");
   });
 });
 

--- a/packages/config-mutations/src/formats/index.ts
+++ b/packages/config-mutations/src/formats/index.ts
@@ -1,17 +1,21 @@
 import type { ConfigFormat } from "../types.js";
 import { jsonFormat } from "./json.js";
 import { tomlFormat } from "./toml.js";
+import { yamlFormat } from "./yaml.js";
 
-export type FormatName = "json" | "toml";
+export type FormatName = "json" | "toml" | "yaml";
 
 const formatRegistry: Record<FormatName, ConfigFormat> = {
   json: jsonFormat,
-  toml: tomlFormat
+  toml: tomlFormat,
+  yaml: yamlFormat
 };
 
 const extensionMap: Record<string, FormatName> = {
   ".json": "json",
-  ".toml": "toml"
+  ".toml": "toml",
+  ".yaml": "yaml",
+  ".yml": "yaml"
 };
 
 /**
@@ -56,3 +60,4 @@ function getExtension(path: string): string {
 
 export { jsonFormat } from "./json.js";
 export { tomlFormat } from "./toml.js";
+export { yamlFormat } from "./yaml.js";

--- a/packages/config-mutations/src/formats/yaml.ts
+++ b/packages/config-mutations/src/formats/yaml.ts
@@ -1,0 +1,88 @@
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import type { ConfigFormat, ConfigObject, ConfigValue } from "../types.js";
+
+function isConfigObject(value: unknown): value is ConfigObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parse(content: string): ConfigObject {
+  if (!content || content.trim() === "") {
+    return {};
+  }
+  const parsed = parseYaml(content);
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+  if (!isConfigObject(parsed)) {
+    throw new Error("Expected YAML object.");
+  }
+  return parsed;
+}
+
+function serialize(obj: ConfigObject): string {
+  const serialized = stringifyYaml(obj);
+  return serialized.endsWith("\n") ? serialized : `${serialized}\n`;
+}
+
+function merge(base: ConfigObject, patch: ConfigObject): ConfigObject {
+  const result: ConfigObject = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      continue;
+    }
+    const existing = result[key];
+    if (isConfigObject(existing) && isConfigObject(value)) {
+      result[key] = merge(existing, value);
+      continue;
+    }
+    result[key] = value as ConfigValue;
+  }
+  return result;
+}
+
+function prune(
+  obj: ConfigObject,
+  shape: ConfigObject
+): { changed: boolean; result: ConfigObject } {
+  let changed = false;
+  const result: ConfigObject = { ...obj };
+
+  for (const [key, pattern] of Object.entries(shape)) {
+    if (!(key in result)) {
+      continue;
+    }
+
+    const current = result[key];
+
+    if (isConfigObject(pattern) && Object.keys(pattern).length === 0) {
+      delete result[key];
+      changed = true;
+      continue;
+    }
+
+    if (isConfigObject(pattern) && isConfigObject(current)) {
+      const { changed: childChanged, result: childResult } = prune(current, pattern);
+      if (childChanged) {
+        changed = true;
+      }
+      if (Object.keys(childResult).length === 0) {
+        delete result[key];
+      } else {
+        result[key] = childResult;
+      }
+      continue;
+    }
+
+    delete result[key];
+    changed = true;
+  }
+
+  return { changed, result };
+}
+
+export const yamlFormat: ConfigFormat = {
+  parse,
+  serialize,
+  merge,
+  prune
+};

--- a/packages/config-mutations/src/mutations/config-mutation.ts
+++ b/packages/config-mutations/src/mutations/config-mutation.ts
@@ -13,7 +13,7 @@ export interface MergeOptions {
   /** Value to merge into the config file */
   value: ValueResolver<ConfigObject>;
   /** Optional explicit format override */
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   /** Optional prune by prefix before merging (TOML) */
   pruneByPrefix?: Record<string, string>;
   /** Optional human-readable label for logging */
@@ -26,7 +26,7 @@ export interface PruneOptions {
   /** Shape to prune from the config file */
   shape: ValueResolver<ConfigObject>;
   /** Optional explicit format override */
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   /** Optional guard - only prune if predicate returns true */
   onlyIf?: (doc: ConfigObject, ctx: MutationOptions) => boolean;
   /** Optional human-readable label for logging */
@@ -37,7 +37,7 @@ export interface TransformOptions {
   /** Target file path (must start with ~) */
   target: ValueResolver<string>;
   /** Optional explicit format override */
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   /** Transform function - receives parsed content, returns transformed content */
   transform: (
     content: ConfigObject,

--- a/packages/config-mutations/src/testing/format-utils.ts
+++ b/packages/config-mutations/src/testing/format-utils.ts
@@ -1,6 +1,7 @@
 import type { ConfigObject } from "../types.js";
 import { jsonFormat } from "../formats/json.js";
 import { tomlFormat } from "../formats/toml.js";
+import { yamlFormat } from "../formats/yaml.js";
 
 export function parseToml(content: string): ConfigObject {
   return tomlFormat.parse(content);
@@ -16,4 +17,12 @@ export function parseJson(content: string): ConfigObject {
 
 export function serializeJson(obj: ConfigObject): string {
   return jsonFormat.serialize(obj);
+}
+
+export function parseYaml(content: string): ConfigObject {
+  return yamlFormat.parse(content);
+}
+
+export function serializeYaml(obj: ConfigObject): string {
+  return yamlFormat.serialize(obj);
 }

--- a/packages/config-mutations/src/testing/index.ts
+++ b/packages/config-mutations/src/testing/index.ts
@@ -4,5 +4,7 @@ export {
   parseToml,
   serializeToml,
   parseJson,
-  serializeJson
+  serializeJson,
+  parseYaml,
+  serializeYaml
 } from "./format-utils.js";

--- a/packages/config-mutations/src/types.ts
+++ b/packages/config-mutations/src/types.ts
@@ -119,7 +119,7 @@ export interface ConfigMergeMutation extends BaseMutation {
   kind: "configMerge";
   target: ValueResolver<string>;
   value: ValueResolver<ConfigObject>;
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   pruneByPrefix?: Record<string, string>;
 }
 
@@ -127,14 +127,14 @@ export interface ConfigPruneMutation extends BaseMutation {
   kind: "configPrune";
   target: ValueResolver<string>;
   shape: ValueResolver<ConfigObject>;
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   onlyIf?: (doc: ConfigObject, ctx: MutationOptions) => boolean;
 }
 
 export interface ConfigTransformMutation extends BaseMutation {
   kind: "configTransform";
   target: ValueResolver<string>;
-  format?: "json" | "toml";
+  format?: "json" | "toml" | "yaml";
   transform: (
     content: ConfigObject,
     ctx: MutationOptions

--- a/packages/py-poe-spawn/src/poe_spawn/types.py
+++ b/packages/py-poe-spawn/src/poe_spawn/types.py
@@ -8,6 +8,7 @@ class Agent(str, Enum):
     CODEX = "codex"
     OPENCODE = "opencode"
     KIMI = "kimi"
+    GOOSE = "goose"
 
 
 class SpawnMode(str, Enum):

--- a/src/cli/cli-utilities.test.ts
+++ b/src/cli/cli-utilities.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
 import { deriveWrapBinaryAliases } from "./binary-aliases.js";
 import type { ProviderService } from "./service-registry.js";
 import { parseMcpOutputFormatPreferences } from "./mcp-output-format.js";
@@ -349,6 +350,67 @@ describe("poe-code command runner", () => {
     expect(settingsJson).toEqual({
       apiKeyHelper: "echo $POE_API_KEY",
       env: { ANTHROPIC_BASE_URL: "https://api.poe.com" }
+    });
+
+    expect(result).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+  });
+
+  it("routes Goose through its isolated home and config directories", async () => {
+    const fs = createHomeFs(homeDir);
+    const baseRunner = vi.fn(async () => ({
+      stdout: "OK\n",
+      stderr: "",
+      exitCode: 0
+    }));
+    const container = createCliContainer({
+      fs,
+      prompts: vi.fn().mockResolvedValue({}),
+      env: { cwd, homeDir, variables: {} },
+      logger: () => {},
+      commandRunner: baseRunner,
+      httpClient: vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            { id: "claude-opus-4.6", context_window: { context_length: 983040 } },
+            { id: "claude-sonnet-4.6", context_window: { context_length: 983040 } },
+            { id: "gpt-5.3-codex", context_window: { context_length: 400000 } },
+            { id: "gpt-5.4", context_window: { context_length: 1050000 } },
+            { id: "gemini-3.1-pro", context_window: { context_length: 1048576 } }
+          ]
+        })
+      }))
+    });
+
+    await storeTestApiKey(fs, homeDir, "sk-test");
+
+    const result = await container.commandRunner("poe-code", [
+      "wrap",
+      "goose",
+      "run",
+      "--help"
+    ]);
+
+    expect(baseRunner).toHaveBeenCalledWith(
+      "goose",
+      ["run", "--help"],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          HOME: "/home/test/.poe-code/goose",
+          XDG_CONFIG_HOME: "/home/test/.poe-code/goose/.config"
+        })
+      })
+    );
+    expect((baseRunner.mock.calls[0]?.[2] as { env: Record<string, string> }).env.POE_API_KEY).toBe(
+      undefined
+    );
+
+    const secrets = parseYaml(
+      await fs.readFile("/home/test/.poe-code/goose/.config/goose/secrets.yaml", "utf8")
+    ) as Record<string, unknown>;
+    expect(secrets).toEqual({
+      CUSTOM_POE_API_KEY: "sk-test"
     });
 
     expect(result).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });

--- a/src/cli/cli-utilities.test.ts
+++ b/src/cli/cli-utilities.test.ts
@@ -266,6 +266,7 @@ describe("listIsolatedServiceIds", () => {
       "claude-code",
       "claude",
       "codex",
+      "goose",
       "kimi",
       "kimi-cli",
       "opencode"
@@ -296,6 +297,7 @@ describe("listIsolatedServiceIds", () => {
       "claude-code",
       "claude",
       "codex",
+      "goose",
       "kimi",
       "kimi-cli",
       "opencode",

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Volume, createFsFromVolume } from "memfs";
+import { parse as parseYaml } from "yaml";
 import { Command } from "commander";
 import { resolveConfigPath } from "@poe-code/poe-code-config";
 import { executeConfigure } from "./configure.js";
@@ -86,9 +87,7 @@ describe("configure command", () => {
     const { container } = createContainer();
 
     vi.spyOn(container.options, "resolveApiKey").mockResolvedValue("sk-test");
-    vi.spyOn(container.options, "resolveModel").mockResolvedValue(
-      "test-model"
-    );
+    vi.spyOn(container.options, "resolveModel").mockResolvedValue("test-model");
     vi.spyOn(container.options, "resolveReasoning").mockResolvedValue("none");
 
     const invokeSpy = vi.spyOn(container.registry, "invoke");
@@ -245,6 +244,40 @@ describe("configure command", () => {
     expect(resolveModel).toHaveBeenCalled();
   });
 
+  it("configures goose and stores its managed files", async () => {
+    const { container } = createContainer();
+    vi.spyOn(container.options, "resolveApiKey").mockResolvedValue("sk-goose");
+    vi.spyOn(container.options, "resolveModel").mockResolvedValue("openai/gpt-5.4");
+
+    const program = createTestProgram();
+    await executeConfigure(program, container, "goose", {});
+
+    const config = parseYaml(
+      await fs.readFile(`${homeDir}/.config/goose/config.yaml`, "utf8")
+    ) as Record<string, unknown>;
+    expect(config.GOOSE_PROVIDER).toBe("custom_poe");
+    expect(config.GOOSE_MODEL).toBe("openai/gpt-5.4");
+
+    const provider = JSON.parse(
+      await fs.readFile(`${homeDir}/.config/goose/custom_providers/custom_poe.json`, "utf8")
+    ) as Record<string, unknown>;
+    expect(provider.name).toBe("custom_poe");
+
+    const secrets = parseYaml(
+      await fs.readFile(`${homeDir}/.config/goose/secrets.yaml`, "utf8")
+    ) as Record<string, unknown>;
+    expect(secrets.CUSTOM_POE_API_KEY).toBe("sk-goose");
+
+    const content = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(content.configured_services.goose).toEqual({
+      files: [
+        `${homeDir}/.config/goose/config.yaml`,
+        `${homeDir}/.config/goose/custom_providers/custom_poe.json`,
+        `${homeDir}/.config/goose/secrets.yaml`
+      ]
+    });
+  });
+
   it("accepts --model option to set a model without prompting", async () => {
     const { container } = createContainer();
     const customModel = "Custom-Model";
@@ -286,7 +319,7 @@ describe("configure command", () => {
   it("prints a VSCode post-configure hint for Claude Code after configure", async () => {
     const logs: string[] = [];
     const { container } = createContainer({
-      logger: (message) => logs.push(message),
+      logger: (message) => logs.push(message)
     });
 
     vi.spyOn(container.options, "resolveApiKey").mockResolvedValue("sk-test");
@@ -327,9 +360,7 @@ describe("generate command", () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    stdoutSpy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(() => true);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -346,12 +377,7 @@ describe("generate command", () => {
     };
     setGlobalClient(client);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "What is 2+2?"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "What is 2+2?"]);
 
     expect(client.text).toHaveBeenCalledWith({
       model: DEFAULT_TEXT_MODEL,
@@ -493,12 +519,7 @@ describe("generate command", () => {
     };
     setGlobalClient(client);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "Hello"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "Hello"]);
 
     expect(client.text).toHaveBeenCalledWith({
       model: "Env-Model",
@@ -526,13 +547,7 @@ describe("generate command", () => {
       arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer
     } as unknown as Response);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "image",
-      "A sunset"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "image", "A sunset"]);
 
     const saved = await fs.readFile("/repo/image-1737984000.png");
     expect(saved).toEqual(Buffer.from([1, 2, 3]));
@@ -561,15 +576,7 @@ describe("generate command", () => {
       arrayBuffer: async () => new Uint8Array([9, 8, 7]).buffer
     } as unknown as Response);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "image",
-      "-o",
-      "custom.png",
-      "A cat"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "image", "-o", "custom.png", "A cat"]);
 
     const saved = await fs.readFile("/repo/custom.png");
     expect(saved).toEqual(Buffer.from([9, 8, 7]));
@@ -598,13 +605,7 @@ describe("generate command", () => {
       arrayBuffer: async () => new Uint8Array([4, 5, 6]).buffer
     } as unknown as Response);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "video",
-      "A rocket launch"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "video", "A rocket launch"]);
 
     const saved = await fs.readFile("/repo/video-1737984000.mp4");
     expect(saved).toEqual(Buffer.from([4, 5, 6]));
@@ -638,15 +639,7 @@ describe("generate command", () => {
       arrayBuffer: async () => new Uint8Array([7, 8, 9]).buffer
     } as unknown as Response);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "audio",
-      "-o",
-      "clip.mp3",
-      "Hello world"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "audio", "-o", "clip.mp3", "Hello world"]);
 
     const saved = await fs.readFile("/repo/clip.mp3");
     expect(saved).toEqual(Buffer.from([7, 8, 9]));
@@ -678,13 +671,7 @@ describe("generate command", () => {
       arrayBuffer: async () => new Uint8Array([1]).buffer
     } as unknown as Response);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "generate",
-      "image",
-      "A bird"
-    ]);
+    await program.parseAsync(["node", "cli", "generate", "image", "A bird"]);
 
     expect(client.media).toHaveBeenCalledWith("image", {
       model: DEFAULT_IMAGE_BOT,
@@ -702,14 +689,7 @@ describe("generate command", () => {
     setGlobalClient(client);
 
     await expect(
-      program.parseAsync([
-        "node",
-        "cli",
-        "generate",
-        "--param",
-        "missing-equals",
-        "Hello"
-      ])
+      program.parseAsync(["node", "cli", "generate", "--param", "missing-equals", "Hello"])
     ).rejects.toThrow("Invalid param format");
   });
 
@@ -721,15 +701,9 @@ describe("generate command", () => {
     };
     setGlobalClient(client);
 
-    await expect(
-      program.parseAsync([
-        "node",
-        "cli",
-        "generate",
-        "image",
-        "A cat"
-      ])
-    ).rejects.toThrow("RAW-RESPONSE");
+    await expect(program.parseAsync(["node", "cli", "generate", "image", "A cat"])).rejects.toThrow(
+      "RAW-RESPONSE"
+    );
   });
 });
 
@@ -739,10 +713,7 @@ describe("install command", () => {
   function createBaseProgram(): Command {
     const program = new Command();
     program.exitOverride();
-    program
-      .name("poe-code")
-      .option("-y, --yes")
-      .option("--dry-run");
+    program.name("poe-code").option("-y, --yes").option("--dry-run");
     return program;
   }
 
@@ -772,17 +743,10 @@ describe("install command", () => {
     const program = createBaseProgram();
     registerInstallCommand(program, container);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "install",
-      "test-service"
-    ]);
+    await program.parseAsync(["node", "cli", "install", "test-service"]);
 
     expect(callOrder).toEqual(["install"]);
-    expect(logs.some((line) => line.includes("Installed Test Service"))).toBe(
-      true
-    );
+    expect(logs.some((line) => line.includes("Installed Test Service"))).toBe(true);
   });
 
   it("resolves the install alias", async () => {
@@ -806,12 +770,7 @@ describe("install command", () => {
     const program = createBaseProgram();
     registerInstallCommand(program, container);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "i",
-      "test-service"
-    ]);
+    await program.parseAsync(["node", "cli", "i", "test-service"]);
 
     expect(install).toHaveBeenCalledOnce();
   });
@@ -1073,10 +1032,7 @@ describe("test command (isolated)", () => {
   function createBaseProgram(): Command {
     const program = new Command();
     program.exitOverride();
-    program
-      .name("poe-code")
-      .option("-y, --yes")
-      .option("--dry-run");
+    program.name("poe-code").option("-y, --yes").option("--dry-run");
     return program;
   }
 
@@ -1131,13 +1087,7 @@ describe("test command (isolated)", () => {
     const program = createBaseProgram();
     registerTestCommand(program, container);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "test",
-      "demo-service",
-      "--isolated"
-    ]);
+    await program.parseAsync(["node", "cli", "test", "demo-service", "--isolated"]);
   });
 });
 
@@ -1164,10 +1114,7 @@ describe("test command", () => {
   function createBaseProgram(): Command {
     const program = new Command();
     program.exitOverride();
-    program
-      .name("poe-code")
-      .option("-y, --yes")
-      .option("--dry-run");
+    program.name("poe-code").option("-y, --yes").option("--dry-run");
     return program;
   }
 
@@ -1206,9 +1153,9 @@ describe("test command", () => {
     const program = createBaseProgram();
     registerTestCommand(program, container);
 
-    await expect(
-      program.parseAsync(["node", "cli", "test", "demo-service"])
-    ).rejects.toThrow(/does not support test/i);
+    await expect(program.parseAsync(["node", "cli", "test", "demo-service"])).rejects.toThrow(
+      /does not support test/i
+    );
   });
 
   it("propagates provider test failures", async () => {
@@ -1226,9 +1173,9 @@ describe("test command", () => {
     const program = createBaseProgram();
     registerTestCommand(program, container);
 
-    await expect(
-      program.parseAsync(["node", "cli", "test", "demo-service"])
-    ).rejects.toThrow(/health check failed/);
+    await expect(program.parseAsync(["node", "cli", "test", "demo-service"])).rejects.toThrow(
+      /health check failed/
+    );
   });
 
   it("passes --model to provider context", async () => {
@@ -1320,19 +1267,10 @@ describe("unconfigure command", () => {
     const program = createBaseProgram();
     registerUnconfigureCommand(program, container);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "unconfigure",
-      "test-service"
-    ]);
+    await program.parseAsync(["node", "cli", "unconfigure", "test-service"]);
 
     expect(unconfigureSpy).toHaveBeenCalledTimes(1);
-    expect(
-      logs.some((line) =>
-        line.includes("Removed Test Service configuration.")
-      )
-    ).toBe(true);
+    expect(logs.some((line) => line.includes("Removed Test Service configuration."))).toBe(true);
   });
 
   it("logs mutation outcomes when provider reports them", async () => {
@@ -1373,19 +1311,11 @@ describe("unconfigure command", () => {
     const program = createBaseProgram();
     registerUnconfigureCommand(program, container);
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "--verbose",
-      "unconfigure",
-      "test-service"
-    ]);
+    await program.parseAsync(["node", "cli", "--verbose", "unconfigure", "test-service"]);
 
     expect(
       logs.some((line) =>
-        line.includes(
-          "Transform file /home/test/.config/opencode/config.json: delete"
-        )
+        line.includes("Transform file /home/test/.config/opencode/config.json: delete")
       )
     ).toBe(true);
   });
@@ -1461,9 +1391,7 @@ describe("version command", () => {
     await parseWithVersionExit(program, ["node", "cli", "--version"]);
 
     expect(logs.some((log) => log.includes("99.0.0"))).toBe(true);
-    expect(
-      logs.some((log) => log.includes("npm install -g poe-code@latest"))
-    ).toBe(true);
+    expect(logs.some((log) => log.includes("npm install -g poe-code@latest"))).toBe(true);
   });
 
   it("does not show update message when version is current", async () => {
@@ -1485,9 +1413,7 @@ describe("version command", () => {
 
     await parseWithVersionExit(program, ["node", "cli", "--version"]);
 
-    expect(
-      logs.some((log) => log.includes("npm install -g poe-code@latest"))
-    ).toBe(false);
+    expect(logs.some((log) => log.includes("npm install -g poe-code@latest"))).toBe(false);
   });
 
   it("shows local build indicator for dev version", async () => {

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -263,17 +263,11 @@ describe("configure command", () => {
     ) as Record<string, unknown>;
     expect(provider.name).toBe("custom_poe");
 
-    const secrets = parseYaml(
-      await fs.readFile(`${homeDir}/.config/goose/secrets.yaml`, "utf8")
-    ) as Record<string, unknown>;
-    expect(secrets.CUSTOM_POE_API_KEY).toBe("sk-goose");
-
     const content = JSON.parse(await fs.readFile(configPath, "utf8"));
     expect(content.configured_services.goose).toEqual({
       files: [
         `${homeDir}/.config/goose/config.yaml`,
-        `${homeDir}/.config/goose/custom_providers/custom_poe.json`,
-        `${homeDir}/.config/goose/secrets.yaml`
+        `${homeDir}/.config/goose/custom_providers/custom_poe.json`
       ]
     });
   });

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -55,6 +55,7 @@ describe("configure command", () => {
     overrides: {
       commandRunner?: CommandRunner;
       logger?: LoggerFn;
+      httpClient?: HttpClient;
     } = {}
   ) {
     const prompts = vi.fn().mockResolvedValue({});
@@ -78,7 +79,8 @@ describe("configure command", () => {
       prompts,
       env: { cwd, homeDir },
       logger,
-      commandRunner
+      commandRunner,
+      httpClient: overrides.httpClient
     });
     return { container, prompts, commandRunner };
   }
@@ -245,7 +247,20 @@ describe("configure command", () => {
   });
 
   it("configures goose and stores its managed files", async () => {
-    const { container } = createContainer();
+    const httpClient = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          { id: "claude-opus-4.6", context_window: { context_length: 983040 } },
+          { id: "claude-sonnet-4.6", context_window: { context_length: 983040 } },
+          { id: "gpt-5.3-codex", context_window: { context_length: 400000 } },
+          { id: "gpt-5.4", context_window: { context_length: 1050000 } },
+          { id: "gemini-3.1-pro", context_window: { context_length: 1048576 } }
+        ]
+      })
+    })) satisfies HttpClient;
+    const { container } = createContainer({ httpClient });
     vi.spyOn(container.options, "resolveApiKey").mockResolvedValue("sk-goose");
     vi.spyOn(container.options, "resolveModel").mockResolvedValue("openai/gpt-5.4");
 
@@ -262,14 +277,57 @@ describe("configure command", () => {
       await fs.readFile(`${homeDir}/.config/goose/custom_providers/custom_poe.json`, "utf8")
     ) as Record<string, unknown>;
     expect(provider.name).toBe("custom_poe");
+    expect(provider.api_key_env).toBe("CUSTOM_POE_API_KEY");
+    expect(provider.models).toEqual([
+      { name: "anthropic/claude-opus-4.6", context_limit: 983040 },
+      { name: "anthropic/claude-sonnet-4.6", context_limit: 983040 },
+      { name: "openai/gpt-5.3-codex", context_limit: 400000 },
+      { name: "openai/gpt-5.4", context_limit: 1050000 },
+      { name: "google/gemini-3.1-pro", context_limit: 1048576 }
+    ]);
+
+    const secrets = parseYaml(
+      await fs.readFile(`${homeDir}/.config/goose/secrets.yaml`, "utf8")
+    ) as Record<string, unknown>;
+    expect(secrets).toEqual({
+      CUSTOM_POE_API_KEY: "sk-goose"
+    });
 
     const content = JSON.parse(await fs.readFile(configPath, "utf8"));
     expect(content.configured_services.goose).toEqual({
       files: [
         `${homeDir}/.config/goose/config.yaml`,
-        `${homeDir}/.config/goose/custom_providers/custom_poe.json`
+        `${homeDir}/.config/goose/custom_providers/custom_poe.json`,
+        `${homeDir}/.config/goose/secrets.yaml`
       ]
     });
+    expect(httpClient).toHaveBeenCalledWith(
+      "https://api.poe.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-goose"
+        })
+      })
+    );
+  });
+
+  it("fails to configure goose when /v1/models does not provide required context lengths", async () => {
+    const httpClient = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ id: "gpt-5.4", context_window: { context_length: 1050000 } }]
+      })
+    })) satisfies HttpClient;
+    const { container } = createContainer({ httpClient });
+    vi.spyOn(container.options, "resolveApiKey").mockResolvedValue("sk-goose");
+    vi.spyOn(container.options, "resolveModel").mockResolvedValue("openai/gpt-5.4");
+
+    const program = createTestProgram();
+
+    await expect(executeConfigure(program, container, "goose", {})).rejects.toThrow(
+      /Missing Goose model context limit/
+    );
   });
 
   it("accepts --model option to set a model without prompting", async () => {

--- a/src/cli/commands/configure-payload.ts
+++ b/src/cli/commands/configure-payload.ts
@@ -57,5 +57,16 @@ export async function createConfigurePayload(
     payload.reasoningEffort = reasoningEffort;
   }
 
+  const extension = await adapter.extendConfigurePayload?.({
+    fs: container.fs,
+    env: context.env,
+    httpClient: container.httpClient,
+    logger,
+    payload
+  });
+  if (extension) {
+    Object.assign(payload, extension);
+  }
+
   return payload;
 }

--- a/src/cli/commands/experiment-ralph.test.ts
+++ b/src/cli/commands/experiment-ralph.test.ts
@@ -5,6 +5,7 @@ import { createCliContainer } from "../container.js";
 import type { FileSystem } from "../../utils/file-system.js";
 import { registerExperimentCommand } from "./experiment.js";
 import { registerRalphCommand } from "./ralph.js";
+import { allSpawnConfigs } from "@poe-code/agent-spawn";
 import { ValidationError } from "../errors.js";
 import experimentSkillPlan from "../../templates/experiment/SKILL_experiment.md";
 import experimentRunYaml from "../../templates/experiment/run.yaml.hbs";
@@ -74,6 +75,13 @@ function createBaseProgram(): Command {
   program.exitOverride();
   program.name("poe-code").option("-y, --yes").option("--dry-run").option("--verbose");
   return program;
+}
+
+function getSpawnAgentOptions() {
+  return allSpawnConfigs.map((config) => ({
+    label: config.agentId,
+    value: config.agentId
+  }));
 }
 
 describe("experiment run command", () => {
@@ -234,12 +242,7 @@ describe("experiment run command", () => {
     });
     expect(selectMock).toHaveBeenNthCalledWith(2, {
       message: "Select agent to run the experiment with:",
-      options: [
-        { label: "claude-code", value: "claude-code" },
-        { label: "codex", value: "codex" },
-        { label: "opencode", value: "opencode" },
-        { label: "kimi", value: "kimi" }
-      ]
+      options: getSpawnAgentOptions()
     });
     expect(vi.mocked(sdkRunExperiment)).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -785,12 +788,7 @@ describe("ralph run command", () => {
     });
     expect(selectMock).toHaveBeenNthCalledWith(2, {
       message: "Select agent to run Ralph with:",
-      options: [
-        { label: "claude-code", value: "claude-code" },
-        { label: "codex", value: "codex" },
-        { label: "opencode", value: "opencode" },
-        { label: "kimi", value: "kimi" }
-      ]
+      options: getSpawnAgentOptions()
     });
     expect(promptTextMock).toHaveBeenCalledWith({
       message: "How many Ralph iterations should run?"

--- a/src/cli/commands/login-mcp.test.ts
+++ b/src/cli/commands/login-mcp.test.ts
@@ -286,7 +286,7 @@ describe("login command", () => {
     const settingsRaw = await fs.readFile(`${homeDir}/.claude/settings.json`, "utf8");
     const settings = JSON.parse(settingsRaw);
     expect(settings.apiKeyHelper).toBe(`echo ${NEW_KEY}`);
-    expect(settings.model).toBe(stripModelNamespace(DEFAULT_CLAUDE_CODE_MODEL));
+    expect(settings.model).toBe(stripModelNamespace(DEFAULT_CLAUDE_CODE_MODEL).replaceAll(".", "-"));
   });
 
   it("uses OAuth flow by default", async () => {

--- a/src/cli/commands/spawn-command.test.ts
+++ b/src/cli/commands/spawn-command.test.ts
@@ -86,9 +86,7 @@ function createCommandRunnerStub(
   return { runner, calls };
 }
 
-function createContainerWithDependencies(
-  overrides: Partial<CliDependencies> = {}
-): {
+function createContainerWithDependencies(overrides: Partial<CliDependencies> = {}): {
   container: ReturnType<typeof createCliContainer>;
   logs: string[];
   commandCalls: CommandCall[];
@@ -100,9 +98,11 @@ function createContainerWithDependencies(
     prompts: overrides.prompts ?? vi.fn().mockResolvedValue({}),
     env: overrides.env ?? { cwd, homeDir },
     commandRunner: overrides.commandRunner ?? runner,
-    logger: overrides.logger ?? ((message) => {
-      logs.push(message);
-    })
+    logger:
+      overrides.logger ??
+      ((message) => {
+        logs.push(message);
+      })
   });
   return { container, logs, commandCalls: calls };
 }
@@ -190,21 +190,13 @@ describe("spawn command", () => {
     vi.useFakeTimers();
 
     const chunks: string[] = [];
-    const spy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(((chunk: unknown) => {
-        chunks.push(String(chunk));
-        return true;
-      }) as unknown as typeof process.stdout.write);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as unknown as typeof process.stdout.write);
 
     try {
-      const parsePromise = program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude",
-        "hello"
-      ]);
+      const parsePromise = program.parseAsync(["node", "cli", "spawn", "claude", "hello"]);
       await vi.runAllTimersAsync();
       await parsePromise;
     } finally {
@@ -220,11 +212,7 @@ describe("spawn command", () => {
     });
 
     const plainChunks = chunks.map((chunk) => stripAnsi(chunk));
-    expect(plainChunks).toEqual([
-      "  → exec: npm test\n",
-      "  ✓ exec\n",
-      "✓ agent: Hi\n"
-    ]);
+    expect(plainChunks).toEqual(["  → exec: npm test\n", "  ✓ exec\n", "✓ agent: Hi\n"]);
     expect(logs.length).toBeGreaterThan(0);
   });
 
@@ -245,21 +233,13 @@ describe("spawn command", () => {
     });
 
     const chunks: string[] = [];
-    const spy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(((chunk: unknown) => {
-        chunks.push(String(chunk));
-        return true;
-      }) as unknown as typeof process.stdout.write);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as unknown as typeof process.stdout.write);
 
     try {
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "codex",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "codex", "hello"]);
     } finally {
       spy.mockRestore();
     }
@@ -299,12 +279,10 @@ describe("spawn command", () => {
     });
 
     const chunks: string[] = [];
-    const spy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(((chunk: unknown) => {
-        chunks.push(String(chunk));
-        return true;
-      }) as unknown as typeof process.stdout.write);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as unknown as typeof process.stdout.write);
 
     try {
       await program.parseAsync(["node", "cli", "--yes", "spawn", "codex", "hello"]);
@@ -364,19 +342,23 @@ describe("spawn command", () => {
     });
 
     const chunks: string[] = [];
-    const spy = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(((chunk: unknown) => {
-        chunks.push(String(chunk));
-        return true;
-      }) as unknown as typeof process.stdout.write);
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      chunks.push(String(chunk));
+      return true;
+    }) as unknown as typeof process.stdout.write);
 
     try {
       await expect(
         program.parseAsync(["node", "cli", "--yes", "spawn", "codex", "hello"])
       ).resolves.toBe(program);
 
-      expect(chunks.join("").trim().split("\n").map((line) => JSON.parse(line))).toEqual([
+      expect(
+        chunks
+          .join("")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line))
+      ).toEqual([
         {
           event: "spawn_result",
           exitCode: 23,
@@ -407,13 +389,7 @@ describe("spawn command", () => {
     });
 
     await expect(
-      program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude-code",
-        "Explain the change"
-      ])
+      program.parseAsync(["node", "cli", "spawn", "claude-code", "Explain the change"])
     ).rejects.toThrow(/spawn failed/i);
   });
 
@@ -439,9 +415,7 @@ describe("spawn command", () => {
 
     expect(calls).toHaveLength(0);
     expect(sdkSpawn).not.toHaveBeenCalled();
-    const dryRunLog = logs.find((line) =>
-      line.includes("Dry run: would spawn Claude Code.")
-    );
+    const dryRunLog = logs.find((line) => line.includes("Dry run: would spawn Claude Code."));
     expect(dryRunLog).toBeTruthy();
     expect(dryRunLog).toContain("Prompt:");
   });
@@ -562,13 +536,7 @@ describe("spawn command", () => {
       logger: () => {}
     });
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "spawn",
-      "codex",
-      "List files"
-    ]);
+    await program.parseAsync(["node", "cli", "spawn", "codex", "List files"]);
 
     expect(sdkSpawn).toHaveBeenCalledWith("codex", {
       prompt: "List files",
@@ -663,15 +631,7 @@ describe("spawn command", () => {
     });
 
     await expect(
-      program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--mcp-servers",
-        "{nope",
-        "codex",
-        "hello"
-      ])
+      program.parseAsync(["node", "cli", "spawn", "--mcp-servers", "{nope", "codex", "hello"])
     ).rejects.toThrow("--mcp-servers");
 
     expect(sdkSpawn).not.toHaveBeenCalled();
@@ -703,9 +663,7 @@ describe("spawn command", () => {
         "kimi",
         "hello"
       ])
-    ).rejects.toThrow(
-      "does not support MCP servers at spawn time."
-    );
+    ).rejects.toThrow("does not support MCP servers at spawn time.");
 
     expect(sdkSpawn).not.toHaveBeenCalled();
   });
@@ -865,16 +823,7 @@ describe("spawn command", () => {
       .mockReturnValue(stdinStream as NodeJS.ReadStream);
 
     try {
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--stdin",
-        "codex",
-        "--",
-        "--foo",
-        "bar"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--stdin", "codex", "--", "--foo", "bar"]);
     } finally {
       stdinSpy.mockRestore();
     }
@@ -911,18 +860,10 @@ describe("spawn command", () => {
         logger: (message) => logs.push(message)
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "codex",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "codex", "hello"]);
 
       const plainLog = stripAnsi(logs.join("\n"));
-      expect(plainLog).toContain(
-        "Resume: codex resume -C /projects/demo thread_abc123"
-      );
+      expect(plainLog).toContain("Resume: codex resume -C /projects/demo thread_abc123");
     } finally {
       processCwdSpy.mockRestore();
     }
@@ -960,9 +901,7 @@ describe("spawn command", () => {
     ]);
 
     const plainLog = stripAnsi(logs.join("\n"));
-    expect(plainLog).toContain(
-      "Resume: codex resume -C '/projects/demo repo' thread_abc123"
-    );
+    expect(plainLog).toContain("Resume: codex resume -C '/projects/demo repo' thread_abc123");
   });
 
   it("does not print a resume command when threadId is missing", async () => {
@@ -985,13 +924,7 @@ describe("spawn command", () => {
       logger: (message) => logs.push(message)
     });
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "spawn",
-      "codex",
-      "hello"
-    ]);
+    await program.parseAsync(["node", "cli", "spawn", "codex", "hello"]);
 
     const plainLog = stripAnsi(logs.join("\n"));
     expect(plainLog).not.toContain("Resume:");
@@ -1021,18 +954,10 @@ describe("spawn command", () => {
         logger: (message) => logs.push(message)
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "claude-code", "hello"]);
 
       const plainLog = stripAnsi(logs.join("\n"));
-      expect(plainLog).toContain(
-        "Resume: cd /projects/demo && claude --resume thread_abc123"
-      );
+      expect(plainLog).toContain("Resume: cd /projects/demo && claude --resume thread_abc123");
     } finally {
       processCwdSpy.mockRestore();
     }
@@ -1062,18 +987,10 @@ describe("spawn command", () => {
         logger: (message) => logs.push(message)
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "opencode",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "opencode", "hello"]);
 
       const plainLog = stripAnsi(logs.join("\n"));
-      expect(plainLog).toContain(
-        "Resume: opencode /projects/demo --session thread_abc123"
-      );
+      expect(plainLog).toContain("Resume: opencode /projects/demo --session thread_abc123");
     } finally {
       processCwdSpy.mockRestore();
     }
@@ -1103,18 +1020,10 @@ describe("spawn command", () => {
         logger: (message) => logs.push(message)
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "kimi",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "kimi", "hello"]);
 
       const plainLog = stripAnsi(logs.join("\n"));
-      expect(plainLog).toContain(
-        "Resume: kimi --session thread_abc123 --work-dir /projects/demo"
-      );
+      expect(plainLog).toContain("Resume: kimi --session thread_abc123 --work-dir /projects/demo");
     } finally {
       processCwdSpy.mockRestore();
     }
@@ -1151,13 +1060,7 @@ describe("spawn command", () => {
       logger: (message) => logs.push(message)
     });
 
-    await program.parseAsync([
-      "node",
-      "cli",
-      "spawn",
-      "codex",
-      "hello"
-    ]);
+    await program.parseAsync(["node", "cli", "spawn", "codex", "hello"]);
 
     const plainLog = stripAnsi(logs.join("\n"));
     expect(plainLog).not.toContain("Resume:");
@@ -1180,14 +1083,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--interactive",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code", "hello"]);
 
       expect(spawnInteractive).toHaveBeenCalledWith("claude-code", {
         prompt: "hello",
@@ -1214,14 +1110,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "-i",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "-i", "claude-code", "hello"]);
 
       expect(spawnInteractive).toHaveBeenCalled();
       expect(sdkSpawn).not.toHaveBeenCalled();
@@ -1245,14 +1134,7 @@ describe("spawn command", () => {
 
       const savedExitCode = process.exitCode;
       try {
-        await program.parseAsync([
-          "node",
-          "cli",
-          "spawn",
-          "--interactive",
-          "claude-code",
-          "hello"
-        ]);
+        await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code", "hello"]);
         expect(process.exitCode).toBe(42);
       } finally {
         process.exitCode = savedExitCode;
@@ -1274,15 +1156,25 @@ describe("spawn command", () => {
       });
 
       await expect(
-        program.parseAsync([
-          "node",
-          "cli",
-          "spawn",
-          "--interactive",
-          "codex",
-          "hello"
-        ])
+        program.parseAsync(["node", "cli", "spawn", "--interactive", "codex", "hello"])
       ).rejects.toThrow("does not support interactive mode");
+    });
+
+    it("rejects interactive goose spawns before calling spawnInteractive", async () => {
+      const { runner } = createCommandRunnerStub();
+      const program = createProgram({
+        fs,
+        prompts: vi.fn().mockResolvedValue({}),
+        env: { cwd, homeDir },
+        commandRunner: runner,
+        logger: () => {}
+      });
+
+      await expect(
+        program.parseAsync(["node", "cli", "spawn", "--interactive", "goose", "hello"])
+      ).rejects.toThrow("Goose does not support interactive mode");
+
+      expect(spawnInteractive).not.toHaveBeenCalled();
     });
 
     it("does not render ACP events in interactive mode", async () => {
@@ -1293,12 +1185,10 @@ describe("spawn command", () => {
       });
 
       const chunks: string[] = [];
-      const spy = vi
-        .spyOn(process.stdout, "write")
-        .mockImplementation(((chunk: unknown) => {
-          chunks.push(String(chunk));
-          return true;
-        }) as unknown as typeof process.stdout.write);
+      const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+        chunks.push(String(chunk));
+        return true;
+      }) as unknown as typeof process.stdout.write);
 
       const { runner } = createCommandRunnerStub();
       const program = createProgram({
@@ -1310,14 +1200,7 @@ describe("spawn command", () => {
       });
 
       try {
-        await program.parseAsync([
-          "node",
-          "cli",
-          "spawn",
-          "--interactive",
-          "claude-code",
-          "hello"
-        ]);
+        await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code", "hello"]);
       } finally {
         spy.mockRestore();
       }
@@ -1342,13 +1225,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--interactive",
-        "claude-code"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code"]);
 
       expect(spawnInteractive).toHaveBeenCalledWith("claude-code", {
         prompt: "",
@@ -1381,14 +1258,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--interactive",
-        "claude",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude", "hello"]);
 
       expect(spawnInteractive).toHaveBeenCalledWith("claude-code", {
         prompt: "hello",
@@ -1443,11 +1313,9 @@ describe("spawn command", () => {
       fileSystem: FileSystem,
       services: Record<string, { files: string[] }>
     ): Promise<void> {
-      await fileSystem.writeFile(
-        configPath,
-        JSON.stringify({ configured_services: services }),
-        { encoding: "utf8" }
-      );
+      await fileSystem.writeFile(configPath, JSON.stringify({ configured_services: services }), {
+        encoding: "utf8"
+      });
     }
 
     it("skips prompt when service is configured", async () => {
@@ -1464,13 +1332,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "claude-code", "hello"]);
 
       expect(confirmMock).not.toHaveBeenCalled();
       expect(sdkSpawn).toHaveBeenCalled();
@@ -1488,13 +1350,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "claude-code", "hello"]);
 
       expect(confirmMock).toHaveBeenCalled();
       expect(sdkSpawn).toHaveBeenCalled();
@@ -1512,13 +1368,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "claude-code", "hello"]);
 
       expect(confirmMock).toHaveBeenCalled();
       expect(sdkSpawn).not.toHaveBeenCalled();
@@ -1538,13 +1388,7 @@ describe("spawn command", () => {
       });
 
       await expect(
-        program.parseAsync([
-          "node",
-          "cli",
-          "spawn",
-          "claude-code",
-          "hello"
-        ])
+        program.parseAsync(["node", "cli", "spawn", "claude-code", "hello"])
       ).rejects.toBeInstanceOf(OperationCancelledError);
 
       expect(confirmMock).toHaveBeenCalled();
@@ -1561,14 +1405,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "--yes",
-        "spawn",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "--yes", "spawn", "claude-code", "hello"]);
 
       expect(confirmMock).not.toHaveBeenCalled();
       expect(sdkSpawn).toHaveBeenCalled();
@@ -1591,14 +1428,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--interactive",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code", "hello"]);
 
       expect(confirmMock).toHaveBeenCalled();
       expect(spawnInteractive).toHaveBeenCalled();
@@ -1621,14 +1451,7 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await program.parseAsync([
-        "node",
-        "cli",
-        "spawn",
-        "--interactive",
-        "claude-code",
-        "hello"
-      ]);
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "claude-code", "hello"]);
 
       expect(confirmMock).toHaveBeenCalled();
       expect(spawnInteractive).not.toHaveBeenCalled();

--- a/src/cli/commands/spawn-command.test.ts
+++ b/src/cli/commands/spawn-command.test.ts
@@ -5,7 +5,11 @@ import { resolveConfigPath } from "@poe-code/poe-code-config";
 import { Readable } from "node:stream";
 import { Command } from "commander";
 import { resetOutputFormatCache } from "@poe-code/design-system";
-import { DEFAULT_CLAUDE_CODE_MODEL, DEFAULT_CODEX_MODEL } from "../constants.js";
+import {
+  DEFAULT_CLAUDE_CODE_MODEL,
+  DEFAULT_CODEX_MODEL,
+  DEFAULT_GOOSE_MODEL
+} from "../constants.js";
 import { createProgram } from "../program.js";
 import { registerSpawnCommand } from "./spawn.js";
 import { createCliContainer, type CliDependencies } from "../container.js";
@@ -1160,7 +1164,13 @@ describe("spawn command", () => {
       ).rejects.toThrow("does not support interactive mode");
     });
 
-    it("rejects interactive goose spawns before calling spawnInteractive", async () => {
+    it("calls spawnInteractive for goose when --interactive is set", async () => {
+      vi.mocked(spawnInteractive).mockResolvedValue({
+        stdout: "",
+        stderr: "",
+        exitCode: 0
+      });
+
       const { runner } = createCommandRunnerStub();
       const program = createProgram({
         fs,
@@ -1170,11 +1180,14 @@ describe("spawn command", () => {
         logger: () => {}
       });
 
-      await expect(
-        program.parseAsync(["node", "cli", "spawn", "--interactive", "goose", "hello"])
-      ).rejects.toThrow("Goose does not support interactive mode");
+      await program.parseAsync(["node", "cli", "spawn", "--interactive", "goose", "hello"]);
 
-      expect(spawnInteractive).not.toHaveBeenCalled();
+      expect(spawnInteractive).toHaveBeenCalledWith("goose", {
+        prompt: "hello",
+        args: [],
+        model: DEFAULT_GOOSE_MODEL,
+        cwd: undefined
+      });
     });
 
     it("does not render ACP events in interactive mode", async () => {

--- a/src/cli/commands/spawn.ts
+++ b/src/cli/commands/spawn.ts
@@ -519,8 +519,7 @@ function assertInteractiveSupport(label: string, service: string): void {
   if (spawnConfig?.kind === "cli" && spawnConfig.interactive) {
     return;
   }
-  const resolvedAgentId = resolveAgentId(service);
-  if (resolvedAgentId && resolvedAgentId !== "goose") {
+  if (resolveAgentId(service)) {
     return;
   }
   throw new ValidationError(`${label} does not support interactive mode.`);

--- a/src/cli/commands/spawn.ts
+++ b/src/cli/commands/spawn.ts
@@ -12,7 +12,13 @@ import {
   type SpawnMode
 } from "@poe-code/agent-spawn";
 import { resolveAgentId } from "@poe-code/agent-defs";
-import { text, confirm, isCancel, resolveOutputFormat, renderMarkdown } from "@poe-code/design-system";
+import {
+  text,
+  confirm,
+  isCancel,
+  resolveOutputFormat,
+  renderMarkdown
+} from "@poe-code/design-system";
 import { loadConfiguredServices } from "../../services/config.js";
 import {
   createExecutionResources,
@@ -509,7 +515,12 @@ function assertSpawnSupport(label: string, service: string, providerSupportsSpaw
 }
 
 function assertInteractiveSupport(label: string, service: string): void {
-  if (resolveAgentId(service)) {
+  const spawnConfig = getSpawnConfig(service);
+  if (spawnConfig?.kind === "cli" && spawnConfig.interactive) {
+    return;
+  }
+  const resolvedAgentId = resolveAgentId(service);
+  if (resolvedAgentId && resolvedAgentId !== "goose") {
     return;
   }
   throw new ValidationError(`${label} does not support interactive mode.`);

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -52,6 +52,9 @@ export const KIMI_MODELS = [
 ] as const;
 export const DEFAULT_KIMI_MODEL = KIMI_MODELS[0];
 
+export const GOOSE_MODELS = FRONTIER_MODELS;
+export const DEFAULT_GOOSE_MODEL = DEFAULT_FRONTIER_MODEL;
+
 export const DEFAULT_REASONING = "medium";
 export const PROVIDER_NAME = "poe";
 export const FEEDBACK_URL = "https://github.com/poe-platform/poe-code/issues";

--- a/src/cli/service-registry.ts
+++ b/src/cli/service-registry.ts
@@ -3,6 +3,7 @@ import type { CommandContext } from "./context.js";
 import type { ScopedLogger } from "./logger.js";
 import type { FileSystem } from "../utils/file-system.js";
 import type { CommandCheck } from "../utils/command-checks.js";
+import type { HttpClient } from "./http.js";
 import type {
   ModelPromptInput,
   ReasoningPromptInput
@@ -51,6 +52,14 @@ export interface ServiceExecutionContext<Options> {
   pathMapper?: ServiceManifestPathMapper;
 }
 
+export interface ProviderConfigurePayloadContext {
+  fs: FileSystem;
+  env: CliEnvironment;
+  httpClient: HttpClient;
+  logger: ScopedLogger;
+  payload: Record<string, unknown>;
+}
+
 export interface ProviderService<
   TConfigure = any,
   TUnconfigure = TConfigure,
@@ -75,6 +84,9 @@ export interface ProviderService<
   supportsMcpSpawn?: boolean;
   configurePrompts?: ProviderConfigurePrompts;
   postConfigureMessages?: string[];
+  extendConfigurePayload?(
+    context: ProviderConfigurePayloadContext
+  ): Promise<Record<string, unknown> | void> | Record<string, unknown> | void;
   isolatedEnv?: ProviderIsolatedEnv;
   install?(context: ProviderContext): Promise<void> | void;
   spawn?(context: ProviderContext, options: TSpawn): Promise<unknown>;

--- a/src/providers/claude-code.ts
+++ b/src/providers/claude-code.ts
@@ -105,7 +105,7 @@ export const claudeCodeService = createProvider<
             env: {
               ANTHROPIC_BASE_URL: options.env.poeBaseUrl
             },
-            model: stripModelNamespace(options.model ?? DEFAULT_CLAUDE_CODE_MODEL)
+            model: stripModelNamespace(options.model ?? DEFAULT_CLAUDE_CODE_MODEL).replaceAll(".", "-")
           };
         }
       })

--- a/src/providers/create-provider.ts
+++ b/src/providers/create-provider.ts
@@ -57,6 +57,11 @@ interface CreateProviderOptions<
   supportsMcpSpawn?: boolean;
   configurePrompts?: ProviderConfigurePrompts;
   postConfigureMessages?: string[];
+  extendConfigurePayload?: ProviderService<
+    ConfigureOptions,
+    UnconfigureOptions,
+    SpawnOptions
+  >["extendConfigurePayload"];
   isolatedEnv?: ProviderIsolatedEnv;
   manifest: ManifestVersionDefinition;
   install?: ServiceInstallDefinition;
@@ -91,6 +96,7 @@ export function createProvider<
     supportsMcpSpawn: opts.supportsMcpSpawn,
     configurePrompts: opts.configurePrompts,
     postConfigureMessages: opts.postConfigureMessages,
+    extendConfigurePayload: opts.extendConfigurePayload,
     isolatedEnv: opts.isolatedEnv,
     async configure(context, runOptions) {
       await runMutations(opts.manifest.configure, {

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -11,7 +11,11 @@ import {
 } from "@poe-code/config-mutations";
 import { type ServiceInstallDefinition } from "../services/service-install.js";
 import { createProvider } from "./create-provider.js";
-import { DEFAULT_GOOSE_MODEL, GOOSE_MODELS } from "../cli/constants.js";
+import {
+  DEFAULT_GOOSE_MODEL,
+  GOOSE_MODELS,
+  stripModelNamespace
+} from "../cli/constants.js";
 import type { ProviderSpawnOptions } from "./spawn-options.js";
 import { gooseAgent } from "@poe-code/agent-defs";
 
@@ -19,6 +23,7 @@ type GooseConfigureContext = {
   env: CliEnvironment;
   apiKey: string;
   model?: string;
+  modelContextLimits?: Record<string, number>;
 };
 
 type GooseUnconfigureContext = {
@@ -28,7 +33,12 @@ type GooseUnconfigureContext = {
 const CUSTOM_PROVIDER_ID = "custom_poe";
 const CUSTOM_PROVIDER_FILE = "~/.config/goose/custom_providers/custom_poe.json";
 const GOOSE_CONFIG_FILE = "~/.config/goose/config.yaml";
+const GOOSE_SECRETS_FILE = "~/.config/goose/secrets.yaml";
+const CUSTOM_PROVIDER_API_KEY_ENV = "CUSTOM_POE_API_KEY";
 const HEALTH_CHECK_PROMPT = "Reply with exactly: GOOSE_OK";
+type GooseModelsResponse = {
+  data?: unknown;
+};
 
 export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
   id: "goose",
@@ -76,18 +86,108 @@ export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
   successMessage: "Installed Goose CLI."
 };
 
-function buildCustomProvider(baseUrl: string): ConfigObject {
+function buildCustomProvider(
+  baseUrl: string,
+  apiKey: string,
+  modelContextLimits: Record<string, number> = {}
+): ConfigObject {
   return {
     name: CUSTOM_PROVIDER_ID,
     engine: "openai",
     display_name: "Poe",
     description: "Poe OpenAI-compatible API",
-    api_key_env: "CUSTOM_POE_API_KEY",
+    api_key_env: CUSTOM_PROVIDER_API_KEY_ENV,
     base_url: `${baseUrl}/chat/completions`,
-    models: [...GOOSE_MODELS],
+    headers: {
+      Authorization: `Bearer ${apiKey}`
+    },
+    models: GOOSE_MODELS.map((name) => ({
+      name,
+      context_limit: resolveGooseModelContextLimit(name, modelContextLimits)
+    })),
     supports_streaming: true,
     requires_auth: true
   };
+}
+
+function resolveGooseModelContextLimit(
+  model: string,
+  modelContextLimits: Record<string, number>
+): number {
+  const stripped = stripModelNamespace(model);
+  const dynamicValue = modelContextLimits[model] ?? modelContextLimits[stripped];
+  if (typeof dynamicValue === "number" && Number.isFinite(dynamicValue) && dynamicValue > 0) {
+    return dynamicValue;
+  }
+  throw new Error(`Missing Goose model context limit for ${model}.`);
+}
+
+function extractGooseModelContextLimits(response: GooseModelsResponse): Record<string, number> {
+  const entries = Array.isArray(response.data) ? response.data : [];
+  const wanted = new Map(GOOSE_MODELS.map((model) => [stripModelNamespace(model), model]));
+  const limits: Record<string, number> = {};
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const rawId = (entry as { id?: unknown }).id;
+    const resolvedModel = typeof rawId === "string" ? wanted.get(rawId) : undefined;
+    if (!resolvedModel) {
+      continue;
+    }
+
+    const rawContextLength = (
+      entry as {
+        context_window?: { context_length?: unknown } | null;
+      }
+    ).context_window?.context_length;
+
+    if (
+      typeof rawContextLength !== "number" ||
+      !Number.isFinite(rawContextLength) ||
+      rawContextLength <= 0
+    ) {
+      continue;
+    }
+
+    limits[resolvedModel] = rawContextLength;
+  }
+
+  return limits;
+}
+
+async function fetchGooseModelContextLimits(input: {
+  apiBaseUrl: string;
+  apiKey: string;
+  httpClient: (url: string, init?: { method?: string; headers?: Record<string, string> }) => Promise<{
+    ok: boolean;
+    status: number;
+    json(): Promise<unknown>;
+  }>;
+}): Promise<Record<string, number>> {
+  const response = await input.httpClient(`${input.apiBaseUrl}/models`, {
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`
+    }
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Poe model catalog for Goose configuration (status ${response.status}).`
+    );
+  }
+
+  const modelContextLimits = extractGooseModelContextLimits(
+    (await response.json()) as GooseModelsResponse
+  );
+  const missing = GOOSE_MODELS.filter((model) => modelContextLimits[model] == null);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing Goose model context limit for ${missing[0]}.`
+    );
+  }
+  return modelContextLimits;
 }
 
 function buildRunOptions(
@@ -137,12 +237,23 @@ export const gooseService = createProvider<
       }))
     }
   },
+  async extendConfigurePayload(context) {
+    const { apiKey } = context.payload as GooseConfigureContext;
+    const modelContextLimits = await fetchGooseModelContextLimits({
+      apiBaseUrl: context.env.poeApiBaseUrl,
+      apiKey,
+      httpClient: context.httpClient
+    });
+    return {
+      modelContextLimits
+    };
+  },
   isolatedEnv: {
     agentBinary: gooseAgent.binaryName!,
     configProbe: { kind: "isolatedFile", relativePath: ".config/goose/config.yaml" },
     env: {
-      GOOSE_PATH_ROOT: { kind: "isolatedDir", relativePath: "" },
-      CUSTOM_POE_API_KEY: { kind: "poeApiKey" }
+      HOME: { kind: "isolatedDir", relativePath: "" },
+      XDG_CONFIG_HOME: { kind: "isolatedDir", relativePath: ".config" }
     }
   },
   manifest: {
@@ -151,8 +262,8 @@ export const gooseService = createProvider<
       configMutation.merge({
         target: CUSTOM_PROVIDER_FILE,
         value: (ctx) => {
-          const { env } = (ctx ?? {}) as unknown as GooseConfigureContext;
-          return buildCustomProvider(env.poeApiBaseUrl);
+          const { env, apiKey, modelContextLimits } = (ctx ?? {}) as unknown as GooseConfigureContext;
+          return buildCustomProvider(env.poeApiBaseUrl, apiKey, modelContextLimits);
         }
       }),
       configMutation.merge({
@@ -162,7 +273,18 @@ export const gooseService = createProvider<
           const { model } = (ctx ?? {}) as unknown as GooseConfigureContext;
           return {
             GOOSE_PROVIDER: CUSTOM_PROVIDER_ID,
-            GOOSE_MODEL: model ?? DEFAULT_GOOSE_MODEL
+            GOOSE_MODEL: model ?? DEFAULT_GOOSE_MODEL,
+            GOOSE_DISABLE_KEYRING: true
+          };
+        }
+      }),
+      configMutation.merge({
+        target: GOOSE_SECRETS_FILE,
+        format: "yaml",
+        value: (ctx) => {
+          const { apiKey } = (ctx ?? {}) as unknown as GooseConfigureContext;
+          return {
+            [CUSTOM_PROVIDER_API_KEY_ENV]: apiKey
           };
         }
       })
@@ -175,7 +297,15 @@ export const gooseService = createProvider<
         onlyIf: (document) => document.GOOSE_PROVIDER === CUSTOM_PROVIDER_ID,
         shape: {
           GOOSE_PROVIDER: true,
-          GOOSE_MODEL: true
+          GOOSE_MODEL: true,
+          GOOSE_DISABLE_KEYRING: true
+        }
+      }),
+      configMutation.prune({
+        target: GOOSE_SECRETS_FILE,
+        format: "yaml",
+        shape: {
+          [CUSTOM_PROVIDER_API_KEY_ENV]: true
         }
       })
     ]

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -1,40 +1,70 @@
-import path from "node:path";
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import type { CliEnvironment } from "../cli/environment.js";
 import {
   createBinaryExistsCheck,
   createCommandExpectationCheck,
   type CommandRunnerOptions
 } from "../utils/command-checks.js";
-import { runServiceInstall, type ServiceInstallDefinition } from "../services/service-install.js";
-import type { ProviderService, ServiceExecutionContext } from "../cli/service-registry.js";
+import {
+  configMutation,
+  fileMutation,
+  type ConfigObject
+} from "@poe-code/config-mutations";
+import { type ServiceInstallDefinition } from "../services/service-install.js";
+import { createProvider } from "./create-provider.js";
 import { DEFAULT_GOOSE_MODEL, GOOSE_MODELS } from "../cli/constants.js";
-import type {
-  EmptyProviderOptions,
-  ModelConfigureOptions,
-  ProviderSpawnOptions
-} from "./spawn-options.js";
+import type { ProviderSpawnOptions } from "./spawn-options.js";
 import { gooseAgent } from "@poe-code/agent-defs";
 
+type GooseConfigureContext = {
+  env: CliEnvironment;
+  apiKey: string;
+  model?: string;
+};
+
+type GooseUnconfigureContext = {
+  env: CliEnvironment;
+};
+
 const CUSTOM_PROVIDER_ID = "custom_poe";
-const CUSTOM_PROVIDER_API_KEY_ENV = "CUSTOM_POE_API_KEY";
-const DEFAULT_CONTEXT_LIMIT = 128000;
+const CUSTOM_PROVIDER_FILE = "~/.config/goose/custom_providers/custom_poe.json";
+const GOOSE_CONFIG_FILE = "~/.config/goose/config.yaml";
+const HEALTH_CHECK_PROMPT = "Reply with exactly: GOOSE_OK";
 
 export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
   id: "goose",
   summary: "Goose CLI",
-  check: createBinaryExistsCheck("goose", "goose-cli-binary", "Goose CLI binary must exist"),
+  check: createBinaryExistsCheck(
+    "goose",
+    "goose-cli-binary",
+    "Goose CLI binary must exist"
+  ),
   steps: [
     {
-      id: "install-goose-cli-unix",
+      id: "install-goose-cli-homebrew-or-script",
+      command: "sh",
+      args: [
+        "-c",
+        [
+          "if command -v brew >/dev/null 2>&1; then",
+          "  brew install block-goose-cli || curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash;",
+          "else",
+          "  curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash;",
+          "fi"
+        ].join(" ")
+      ],
+      platforms: ["darwin"]
+    },
+    {
+      id: "install-goose-cli-script-unix",
       command: "sh",
       args: [
         "-c",
         "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"
       ],
-      platforms: ["darwin", "linux"]
+      platforms: ["linux"]
     },
     {
-      id: "install-goose-cli-windows",
+      id: "install-goose-cli-script-windows",
       command: "powershell",
       args: [
         "-Command",
@@ -46,156 +76,21 @@ export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
   successMessage: "Installed Goose CLI."
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function deepMerge(
-  base: Record<string, unknown>,
-  patch: Record<string, unknown>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = { ...base };
-
-  for (const [key, value] of Object.entries(patch)) {
-    const current = result[key];
-    if (isRecord(current) && isRecord(value)) {
-      result[key] = deepMerge(current, value);
-      continue;
-    }
-    result[key] = value;
-  }
-
-  return result;
-}
-
-async function readTextIfExists(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string
-): Promise<string | undefined> {
-  try {
-    return await fs.readFile(filePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-async function readYamlObject(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string
-): Promise<Record<string, unknown>> {
-  const content = await readTextIfExists(fs, filePath);
-  if (!content || content.trim().length === 0) {
-    return {};
-  }
-  const parsed = parseYaml(content);
-  if (!parsed) {
-    return {};
-  }
-  if (!isRecord(parsed)) {
-    throw new Error(`Expected YAML object in ${filePath}.`);
-  }
-  return parsed;
-}
-
-async function readJsonObject(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string
-): Promise<Record<string, unknown>> {
-  const content = await readTextIfExists(fs, filePath);
-  if (!content || content.trim().length === 0) {
-    return {};
-  }
-  const parsed = JSON.parse(content) as unknown;
-  if (!isRecord(parsed)) {
-    throw new Error(`Expected JSON object in ${filePath}.`);
-  }
-  return parsed;
-}
-
-async function writeYamlObject(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string,
-  value: Record<string, unknown>
-): Promise<void> {
-  const serialized = stringifyYaml(value);
-  await fs.writeFile(filePath, serialized.endsWith("\n") ? serialized : `${serialized}\n`, {
-    encoding: "utf8"
-  });
-}
-
-async function writeJsonObject(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string,
-  value: Record<string, unknown>
-): Promise<void> {
-  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
-    encoding: "utf8"
-  });
-}
-
-function managedExtension(
-  name: "developer" | "summon",
-  description: string
-): Record<string, unknown> {
-  return {
-    enabled: true,
-    type: "platform",
-    name,
-    description,
-    display_name: name[0].toUpperCase() + name.slice(1),
-    bundled: true,
-    available_tools: []
-  };
-}
-
-function buildManagedConfig(model: string): Record<string, unknown> {
-  return {
-    GOOSE_DISABLE_KEYRING: true,
-    GOOSE_PROVIDER: CUSTOM_PROVIDER_ID,
-    GOOSE_MODEL: model,
-    extensions: {
-      developer: managedExtension("developer", "Write and edit files, and execute shell commands"),
-      summon: managedExtension("summon", "Load knowledge and delegate tasks to subagents")
-    }
-  };
-}
-
-function buildCustomProvider(baseUrl: string): Record<string, unknown> {
+function buildCustomProvider(baseUrl: string): ConfigObject {
   return {
     name: CUSTOM_PROVIDER_ID,
     engine: "openai",
     display_name: "Poe",
     description: "Poe OpenAI-compatible API",
-    api_key_env: CUSTOM_PROVIDER_API_KEY_ENV,
-    base_url: `${baseUrl}/v1/chat/completions`,
-    models: GOOSE_MODELS.map((name) => ({
-      name,
-      context_limit: DEFAULT_CONTEXT_LIMIT
-    })),
+    api_key_env: "CUSTOM_POE_API_KEY",
+    base_url: `${baseUrl}/chat/completions`,
+    models: [...GOOSE_MODELS],
     supports_streaming: true,
     requires_auth: true
   };
 }
 
-async function removeFileIfExists(
-  fs: ServiceExecutionContext<unknown>["fs"],
-  filePath: string
-): Promise<boolean> {
-  try {
-    await fs.unlink(filePath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw error;
-  }
-}
-
-function createRunOptions(
+function buildRunOptions(
   options: ProviderSpawnOptions,
   model: string
 ): { args: string[]; commandOptions?: CommandRunnerOptions } {
@@ -225,11 +120,11 @@ function createRunOptions(
   };
 }
 
-export const gooseService: ProviderService<
-  ModelConfigureOptions & { apiKey: string },
-  EmptyProviderOptions,
+export const gooseService = createProvider<
+  GooseConfigureContext,
+  GooseUnconfigureContext,
   ProviderSpawnOptions
-> = {
+>({
   ...gooseAgent,
   supportsStdinPrompt: true,
   configurePrompts: {
@@ -242,134 +137,67 @@ export const gooseService: ProviderService<
       }))
     }
   },
-  async configure(context, runOptions) {
-    const configDir = context.env.resolveHomePath(".config", "goose");
-    const configPath = path.join(configDir, "config.yaml");
-    const secretsPath = path.join(configDir, "secrets.yaml");
-    const customProvidersDir = path.join(configDir, "custom_providers");
-    const customProviderPath = path.join(customProvidersDir, "custom_poe.json");
-    const model = context.options.model ?? DEFAULT_GOOSE_MODEL;
-
-    await context.fs.mkdir(configDir, { recursive: true });
-    await context.fs.mkdir(customProvidersDir, { recursive: true });
-
-    const existingConfig = await readYamlObject(context.fs, configPath);
-    const existingSecrets = await readYamlObject(context.fs, secretsPath);
-    const existingProvider = await readJsonObject(context.fs, customProviderPath);
-
-    await writeYamlObject(
-      context.fs,
-      configPath,
-      deepMerge(existingConfig, buildManagedConfig(model))
-    );
-    await writeYamlObject(
-      context.fs,
-      secretsPath,
-      deepMerge(existingSecrets, {
-        [CUSTOM_PROVIDER_API_KEY_ENV]: context.options.apiKey
+  isolatedEnv: {
+    agentBinary: gooseAgent.binaryName!,
+    configProbe: { kind: "isolatedFile", relativePath: ".config/goose/config.yaml" },
+    env: {
+      GOOSE_PATH_ROOT: { kind: "isolatedDir", relativePath: "" },
+      CUSTOM_POE_API_KEY: { kind: "poeApiKey" }
+    }
+  },
+  manifest: {
+    configure: [
+      fileMutation.ensureDirectory({ path: "~/.config/goose/custom_providers" }),
+      configMutation.merge({
+        target: CUSTOM_PROVIDER_FILE,
+        value: (ctx) => {
+          const { env } = (ctx ?? {}) as unknown as GooseConfigureContext;
+          return buildCustomProvider(env.poeApiBaseUrl);
+        }
+      }),
+      configMutation.merge({
+        target: GOOSE_CONFIG_FILE,
+        format: "yaml",
+        value: (ctx) => {
+          const { model } = (ctx ?? {}) as unknown as GooseConfigureContext;
+          return {
+            GOOSE_PROVIDER: CUSTOM_PROVIDER_ID,
+            GOOSE_MODEL: model ?? DEFAULT_GOOSE_MODEL
+          };
+        }
       })
-    );
-    await writeJsonObject(
-      context.fs,
-      customProviderPath,
-      deepMerge(existingProvider, buildCustomProvider(context.env.poeBaseUrl))
-    );
-
-    const observer = runOptions?.observers?.onComplete;
-    if (observer) {
-      for (const targetPath of [configPath, customProviderPath, secretsPath]) {
-        observer(
-          {
-            kind: "configTransform",
-            label: `Update ${targetPath}`,
-            targetPath
-          },
-          {
-            changed: true,
-            effect: "write",
-            detail: "update"
-          }
-        );
-      }
-    }
-
-    context.command.flushDryRun({ emitIfEmpty: false });
+    ],
+    unconfigure: [
+      fileMutation.remove({ target: CUSTOM_PROVIDER_FILE }),
+      configMutation.prune({
+        target: GOOSE_CONFIG_FILE,
+        format: "yaml",
+        onlyIf: (document) => document.GOOSE_PROVIDER === CUSTOM_PROVIDER_ID,
+        shape: {
+          GOOSE_PROVIDER: true,
+          GOOSE_MODEL: true
+        }
+      })
+    ]
   },
-  async unconfigure(context) {
-    const configPath = context.env.resolveHomePath(".config", "goose", "config.yaml");
-    const secretsPath = context.env.resolveHomePath(".config", "goose", "secrets.yaml");
-    const customProviderPath = context.env.resolveHomePath(
-      ".config",
-      "goose",
-      "custom_providers",
-      "custom_poe.json"
-    );
-
-    let changed = false;
-
-    const config = await readYamlObject(context.fs, configPath);
-    for (const key of ["GOOSE_PROVIDER", "GOOSE_MODEL"]) {
-      if (key in config) {
-        delete config[key];
-        changed = true;
-      }
-    }
-    if (changed) {
-      await writeYamlObject(context.fs, configPath, config);
-    }
-
-    const secrets = await readYamlObject(context.fs, secretsPath);
-    if (CUSTOM_PROVIDER_API_KEY_ENV in secrets) {
-      delete secrets[CUSTOM_PROVIDER_API_KEY_ENV];
-      changed = true;
-      if (Object.keys(secrets).length === 0) {
-        await removeFileIfExists(context.fs, secretsPath);
-      } else {
-        await writeYamlObject(context.fs, secretsPath, secrets);
-      }
-    }
-
-    changed = (await removeFileIfExists(context.fs, customProviderPath)) || changed;
-
-    context.command.flushDryRun({ emitIfEmpty: false });
-    return changed;
-  },
-  async install(context) {
-    await runServiceInstall(GOOSE_INSTALL_DEFINITION, {
-      isDryRun: context.logger.context.dryRun,
-      runCommand: context.command.runCommand,
-      logger: (message) => context.logger.verbose(message),
-      platform: context.env.platform
-    });
-  },
+  install: GOOSE_INSTALL_DEFINITION,
   test(context) {
-    const model = context.model ?? DEFAULT_GOOSE_MODEL;
     return context.runCheck(
       createCommandExpectationCheck({
         id: "goose-cli-health",
         command: "goose",
-        args: [
-          "run",
-          "--provider",
-          CUSTOM_PROVIDER_ID,
-          "--model",
-          model,
-          "--text",
-          "Reply with exactly: GOOSE_OK",
-          "--output-format",
-          "text"
-        ],
+        args: ["run", "--text", HEALTH_CHECK_PROMPT, "--output-format", "text"],
         expectedOutput: "GOOSE_OK"
       })
     );
   },
   spawn(context, options) {
     const model = options.model ?? DEFAULT_GOOSE_MODEL;
-    const { args, commandOptions } = createRunOptions(options, model);
+    const { args, commandOptions } = buildRunOptions(options, model);
     return commandOptions
       ? context.command.runCommand("goose", args, commandOptions)
       : context.command.runCommand("goose", args);
   }
-};
+});
 
 export const provider = gooseService;

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -1,0 +1,375 @@
+import path from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import {
+  createBinaryExistsCheck,
+  createCommandExpectationCheck,
+  type CommandRunnerOptions
+} from "../utils/command-checks.js";
+import { runServiceInstall, type ServiceInstallDefinition } from "../services/service-install.js";
+import type { ProviderService, ServiceExecutionContext } from "../cli/service-registry.js";
+import { DEFAULT_GOOSE_MODEL, GOOSE_MODELS } from "../cli/constants.js";
+import type {
+  EmptyProviderOptions,
+  ModelConfigureOptions,
+  ProviderSpawnOptions
+} from "./spawn-options.js";
+import { gooseAgent } from "@poe-code/agent-defs";
+
+const CUSTOM_PROVIDER_ID = "custom_poe";
+const CUSTOM_PROVIDER_API_KEY_ENV = "CUSTOM_POE_API_KEY";
+const DEFAULT_CONTEXT_LIMIT = 128000;
+
+export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
+  id: "goose",
+  summary: "Goose CLI",
+  check: createBinaryExistsCheck("goose", "goose-cli-binary", "Goose CLI binary must exist"),
+  steps: [
+    {
+      id: "install-goose-cli-unix",
+      command: "sh",
+      args: [
+        "-c",
+        "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"
+      ],
+      platforms: ["darwin", "linux"]
+    },
+    {
+      id: "install-goose-cli-windows",
+      command: "powershell",
+      args: [
+        "-Command",
+        "irm https://github.com/block/goose/releases/download/stable/download_cli.ps1 | iex"
+      ],
+      platforms: ["win32"]
+    }
+  ],
+  successMessage: "Installed Goose CLI."
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(
+  base: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+
+  for (const [key, value] of Object.entries(patch)) {
+    const current = result[key];
+    if (isRecord(current) && isRecord(value)) {
+      result[key] = deepMerge(current, value);
+      continue;
+    }
+    result[key] = value;
+  }
+
+  return result;
+}
+
+async function readTextIfExists(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string
+): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function readYamlObject(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string
+): Promise<Record<string, unknown>> {
+  const content = await readTextIfExists(fs, filePath);
+  if (!content || content.trim().length === 0) {
+    return {};
+  }
+  const parsed = parseYaml(content);
+  if (!parsed) {
+    return {};
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`Expected YAML object in ${filePath}.`);
+  }
+  return parsed;
+}
+
+async function readJsonObject(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string
+): Promise<Record<string, unknown>> {
+  const content = await readTextIfExists(fs, filePath);
+  if (!content || content.trim().length === 0) {
+    return {};
+  }
+  const parsed = JSON.parse(content) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error(`Expected JSON object in ${filePath}.`);
+  }
+  return parsed;
+}
+
+async function writeYamlObject(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string,
+  value: Record<string, unknown>
+): Promise<void> {
+  const serialized = stringifyYaml(value);
+  await fs.writeFile(filePath, serialized.endsWith("\n") ? serialized : `${serialized}\n`, {
+    encoding: "utf8"
+  });
+}
+
+async function writeJsonObject(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string,
+  value: Record<string, unknown>
+): Promise<void> {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8"
+  });
+}
+
+function managedExtension(
+  name: "developer" | "summon",
+  description: string
+): Record<string, unknown> {
+  return {
+    enabled: true,
+    type: "platform",
+    name,
+    description,
+    display_name: name[0].toUpperCase() + name.slice(1),
+    bundled: true,
+    available_tools: []
+  };
+}
+
+function buildManagedConfig(model: string): Record<string, unknown> {
+  return {
+    GOOSE_DISABLE_KEYRING: true,
+    GOOSE_PROVIDER: CUSTOM_PROVIDER_ID,
+    GOOSE_MODEL: model,
+    extensions: {
+      developer: managedExtension("developer", "Write and edit files, and execute shell commands"),
+      summon: managedExtension("summon", "Load knowledge and delegate tasks to subagents")
+    }
+  };
+}
+
+function buildCustomProvider(baseUrl: string): Record<string, unknown> {
+  return {
+    name: CUSTOM_PROVIDER_ID,
+    engine: "openai",
+    display_name: "Poe",
+    description: "Poe OpenAI-compatible API",
+    api_key_env: CUSTOM_PROVIDER_API_KEY_ENV,
+    base_url: `${baseUrl}/v1/chat/completions`,
+    models: GOOSE_MODELS.map((name) => ({
+      name,
+      context_limit: DEFAULT_CONTEXT_LIMIT
+    })),
+    supports_streaming: true,
+    requires_auth: true
+  };
+}
+
+async function removeFileIfExists(
+  fs: ServiceExecutionContext<unknown>["fs"],
+  filePath: string
+): Promise<boolean> {
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function createRunOptions(
+  options: ProviderSpawnOptions,
+  model: string
+): { args: string[]; commandOptions?: CommandRunnerOptions } {
+  const baseArgs = [
+    "run",
+    "--provider",
+    CUSTOM_PROVIDER_ID,
+    "--model",
+    model,
+    "--output-format",
+    "text"
+  ];
+
+  if (options.useStdin) {
+    return {
+      args: [...baseArgs, "--instructions", "-", ...(options.args ?? [])],
+      commandOptions: {
+        ...(options.cwd ? { cwd: options.cwd } : {}),
+        stdin: options.prompt
+      }
+    };
+  }
+
+  return {
+    args: [...baseArgs, "--text", options.prompt, ...(options.args ?? [])],
+    commandOptions: options.cwd ? { cwd: options.cwd } : undefined
+  };
+}
+
+export const gooseService: ProviderService<
+  ModelConfigureOptions & { apiKey: string },
+  EmptyProviderOptions,
+  ProviderSpawnOptions
+> = {
+  ...gooseAgent,
+  supportsStdinPrompt: true,
+  configurePrompts: {
+    model: {
+      label: "Goose default model",
+      defaultValue: DEFAULT_GOOSE_MODEL,
+      choices: GOOSE_MODELS.map((id) => ({
+        title: id,
+        value: id
+      }))
+    }
+  },
+  async configure(context, runOptions) {
+    const configDir = context.env.resolveHomePath(".config", "goose");
+    const configPath = path.join(configDir, "config.yaml");
+    const secretsPath = path.join(configDir, "secrets.yaml");
+    const customProvidersDir = path.join(configDir, "custom_providers");
+    const customProviderPath = path.join(customProvidersDir, "custom_poe.json");
+    const model = context.options.model ?? DEFAULT_GOOSE_MODEL;
+
+    await context.fs.mkdir(configDir, { recursive: true });
+    await context.fs.mkdir(customProvidersDir, { recursive: true });
+
+    const existingConfig = await readYamlObject(context.fs, configPath);
+    const existingSecrets = await readYamlObject(context.fs, secretsPath);
+    const existingProvider = await readJsonObject(context.fs, customProviderPath);
+
+    await writeYamlObject(
+      context.fs,
+      configPath,
+      deepMerge(existingConfig, buildManagedConfig(model))
+    );
+    await writeYamlObject(
+      context.fs,
+      secretsPath,
+      deepMerge(existingSecrets, {
+        [CUSTOM_PROVIDER_API_KEY_ENV]: context.options.apiKey
+      })
+    );
+    await writeJsonObject(
+      context.fs,
+      customProviderPath,
+      deepMerge(existingProvider, buildCustomProvider(context.env.poeBaseUrl))
+    );
+
+    const observer = runOptions?.observers?.onComplete;
+    if (observer) {
+      for (const targetPath of [configPath, customProviderPath, secretsPath]) {
+        observer(
+          {
+            kind: "configTransform",
+            label: `Update ${targetPath}`,
+            targetPath
+          },
+          {
+            changed: true,
+            effect: "write",
+            detail: "update"
+          }
+        );
+      }
+    }
+
+    context.command.flushDryRun({ emitIfEmpty: false });
+  },
+  async unconfigure(context) {
+    const configPath = context.env.resolveHomePath(".config", "goose", "config.yaml");
+    const secretsPath = context.env.resolveHomePath(".config", "goose", "secrets.yaml");
+    const customProviderPath = context.env.resolveHomePath(
+      ".config",
+      "goose",
+      "custom_providers",
+      "custom_poe.json"
+    );
+
+    let changed = false;
+
+    const config = await readYamlObject(context.fs, configPath);
+    for (const key of ["GOOSE_PROVIDER", "GOOSE_MODEL"]) {
+      if (key in config) {
+        delete config[key];
+        changed = true;
+      }
+    }
+    if (changed) {
+      await writeYamlObject(context.fs, configPath, config);
+    }
+
+    const secrets = await readYamlObject(context.fs, secretsPath);
+    if (CUSTOM_PROVIDER_API_KEY_ENV in secrets) {
+      delete secrets[CUSTOM_PROVIDER_API_KEY_ENV];
+      changed = true;
+      if (Object.keys(secrets).length === 0) {
+        await removeFileIfExists(context.fs, secretsPath);
+      } else {
+        await writeYamlObject(context.fs, secretsPath, secrets);
+      }
+    }
+
+    changed = (await removeFileIfExists(context.fs, customProviderPath)) || changed;
+
+    context.command.flushDryRun({ emitIfEmpty: false });
+    return changed;
+  },
+  async install(context) {
+    await runServiceInstall(GOOSE_INSTALL_DEFINITION, {
+      isDryRun: context.logger.context.dryRun,
+      runCommand: context.command.runCommand,
+      logger: (message) => context.logger.verbose(message),
+      platform: context.env.platform
+    });
+  },
+  test(context) {
+    const model = context.model ?? DEFAULT_GOOSE_MODEL;
+    return context.runCheck(
+      createCommandExpectationCheck({
+        id: "goose-cli-health",
+        command: "goose",
+        args: [
+          "run",
+          "--provider",
+          CUSTOM_PROVIDER_ID,
+          "--model",
+          model,
+          "--text",
+          "Reply with exactly: GOOSE_OK",
+          "--output-format",
+          "text"
+        ],
+        expectedOutput: "GOOSE_OK"
+      })
+    );
+  },
+  spawn(context, options) {
+    const model = options.model ?? DEFAULT_GOOSE_MODEL;
+    const { args, commandOptions } = createRunOptions(options, model);
+    return commandOptions
+      ? context.command.runCommand("goose", args, commandOptions)
+      : context.command.runCommand("goose", args);
+  }
+};
+
+export const provider = gooseService;

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import path from "node:path";
 import fs from "node:fs";
+import { parse as parseYaml } from "yaml";
 import type { FileSystem } from "../utils/file-system.js";
 import type { ProviderContext } from "../cli/service-registry.js";
 import { createCliEnvironment } from "../cli/environment.js";
@@ -13,15 +14,13 @@ import {
   type MockFileSystem
 } from "@poe-code/config-mutations/testing";
 import { createCliContainer } from "../cli/container.js";
-import {
-  buildProviderContext,
-  createExecutionResources
-} from "../cli/commands/shared.js";
+import { buildProviderContext, createExecutionResources } from "../cli/commands/shared.js";
 import { createProviderStub } from "../../tests/provider-stub.js";
 import * as claudeService from "./claude-code.js";
 import * as codexService from "./codex.js";
 import * as kimiService from "./kimi.js";
 import * as opencodeService from "./opencode.js";
+import * as gooseService from "./goose.js";
 import { provider as poeAgentProvider, spawnPoeAgentWithAcp } from "./poe-agent.js";
 import { AcpClient } from "@poe-code/poe-acp-client";
 import {
@@ -29,9 +28,11 @@ import {
   stripModelNamespace,
   DEFAULT_CODEX_MODEL,
   DEFAULT_KIMI_MODEL,
+  DEFAULT_GOOSE_MODEL,
   KIMI_MODELS,
   DEFAULT_FRONTIER_MODEL,
   FRONTIER_MODELS,
+  GOOSE_MODELS,
   PROVIDER_NAME
 } from "../cli/constants.js";
 
@@ -43,9 +44,8 @@ vi.mock("@poe-code/poe-agent", () => ({
   createAgentSession: createAgentSessionMock
 }));
 
-const resolveVariantModel = (
-  variant: keyof typeof CLAUDE_CODE_VARIANTS
-): string => CLAUDE_CODE_VARIANTS[variant];
+const resolveVariantModel = (variant: keyof typeof CLAUDE_CODE_VARIANTS): string =>
+  CLAUDE_CODE_VARIANTS[variant];
 
 const CLAUDE_MODEL_HAIKU = resolveVariantModel("haiku");
 const CLAUDE_MODEL_SONNET = resolveVariantModel("sonnet");
@@ -151,9 +151,7 @@ describe("claude-code service", () => {
     typeof claudeService.claudeCodeService.unconfigure
   >[0]["options"];
 
-  const buildConfigureOptions = (
-    overrides: Partial<ConfigureOptions> = {}
-  ): ConfigureOptions => ({
+  const buildConfigureOptions = (overrides: Partial<ConfigureOptions> = {}): ConfigureOptions => ({
     env,
     apiKey: "sk-test",
     model: CLAUDE_MODEL_SONNET,
@@ -167,9 +165,7 @@ describe("claude-code service", () => {
     ...overrides
   });
 
-  async function configureClaude(
-    overrides: Partial<ConfigureOptions> = {}
-  ): Promise<void> {
+  async function configureClaude(overrides: Partial<ConfigureOptions> = {}): Promise<void> {
     await claudeService.claudeCodeService.configure({
       fs: mockFsObj,
       env,
@@ -178,9 +174,7 @@ describe("claude-code service", () => {
     });
   }
 
-  async function unconfigureClaude(
-    overrides: Partial<UnconfigureOptions> = {}
-  ): Promise<boolean> {
+  async function unconfigureClaude(overrides: Partial<UnconfigureOptions> = {}): Promise<boolean> {
     return claudeService.claudeCodeService.unconfigure({
       fs: mockFsObj,
       env,
@@ -340,8 +334,10 @@ describe("claude-code service", () => {
     expect(runCommand).toHaveBeenCalledWith(
       "claude",
       expect.arrayContaining([
-        "-p", "Output exactly: CLAUDE_CODE_OK",
-        "--model", expect.stringContaining("claude-sonnet-4-6")
+        "-p",
+        "Output exactly: CLAUDE_CODE_OK",
+        "--model",
+        expect.stringContaining("claude-sonnet-4-6")
       ])
     );
   });
@@ -363,9 +359,7 @@ describe("claude-code service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      claudeService.claudeCodeService.test?.(context)
-    ).rejects.toThrow(/FAIL_STDOUT/);
+    await expect(claudeService.claudeCodeService.test?.(context)).rejects.toThrow(/FAIL_STDOUT/);
   });
 
   it("includes stdout and stderr when the Claude health check output is unexpected", async () => {
@@ -376,9 +370,7 @@ describe("claude-code service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      claudeService.claudeCodeService.test?.(context)
-    ).rejects.toThrow(/CLAUDE_CODE_OK/);
+    await expect(claudeService.claudeCodeService.test?.(context)).rejects.toThrow(/CLAUDE_CODE_OK/);
   });
 
   it("falls back to Windows path lookup when which is unavailable", async () => {
@@ -458,17 +450,11 @@ describe("codex service", () => {
     return { context, logs };
   }
 
-  type ConfigureOptions = Parameters<
-    typeof codexService.codexService.configure
-  >[0]["options"];
+  type ConfigureOptions = Parameters<typeof codexService.codexService.configure>[0]["options"];
 
-  type UnconfigureOptions = Parameters<
-    typeof codexService.codexService.unconfigure
-  >[0]["options"];
+  type UnconfigureOptions = Parameters<typeof codexService.codexService.unconfigure>[0]["options"];
 
-  const buildConfigureOptions = (
-    overrides: Partial<ConfigureOptions> = {}
-  ): ConfigureOptions => ({
+  const buildConfigureOptions = (overrides: Partial<ConfigureOptions> = {}): ConfigureOptions => ({
     env,
     apiKey: "sk-test",
     model: DEFAULT_CODEX_MODEL,
@@ -483,9 +469,7 @@ describe("codex service", () => {
     ...overrides
   });
 
-  async function configureCodex(
-    overrides: Partial<ConfigureOptions> = {}
-  ): Promise<void> {
+  async function configureCodex(overrides: Partial<ConfigureOptions> = {}): Promise<void> {
     await codexService.codexService.configure({
       fs: mockFsObj,
       env,
@@ -494,9 +478,7 @@ describe("codex service", () => {
     });
   }
 
-  async function unconfigureCodex(
-    overrides: Partial<UnconfigureOptions> = {}
-  ): Promise<boolean> {
+  async function unconfigureCodex(overrides: Partial<UnconfigureOptions> = {}): Promise<boolean> {
     return codexService.codexService.unconfigure({
       fs: mockFsObj,
       env,
@@ -514,8 +496,7 @@ describe("codex service", () => {
     expect(doc["model_provider"]).toBe("poe");
 
     const profiles = doc["profiles"] as Record<string, Record<string, unknown>>;
-    const defaultProfileName =
-      codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
+    const defaultProfileName = codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
     const codexProfile = profiles[defaultProfileName];
     expect(codexProfile["model"]).toBe(stripModelNamespace(DEFAULT_CODEX_MODEL));
     expect(codexProfile["model_provider"]).toBe("poe");
@@ -527,8 +508,7 @@ describe("codex service", () => {
     expect(providers["poe"]["requires_openai_auth"]).toBe(false);
     expect(providers["poe"]["supports_websockets"]).toBe(false);
 
-    await expect(mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")).rejects
-      .toThrow();
+    await expect(mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")).rejects.toThrow();
 
     await expect(
       mockFsObj.readFile(`${configPath}.backup.20240101T000000`, "utf8")
@@ -559,8 +539,7 @@ describe("codex service", () => {
 
     const doc = parseToml(await mockFsObj.readFile(configPath, "utf8"));
     const profiles = doc["profiles"] as Record<string, Record<string, unknown>>;
-    const defaultProfileName =
-      codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
+    const defaultProfileName = codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
     expect(profiles["opus"]).toBeDefined();
     expect(profiles[defaultProfileName]).toBeUndefined();
   });
@@ -588,11 +567,9 @@ describe("codex service", () => {
       timestamp: () => "20240101T000000"
     });
 
-    await mockFsObj.writeFile(
-      `${configPath}.backup.20240101T000000`,
-      "legacy",
-      { encoding: "utf8" }
-    );
+    await mockFsObj.writeFile(`${configPath}.backup.20240101T000000`, "legacy", {
+      encoding: "utf8"
+    });
     const removed = await unconfigureCodex();
     expect(removed).toBe(true);
 
@@ -749,24 +726,18 @@ describe("codex service", () => {
     await configureCodex();
 
     const files = mockFs.files;
-    const backupFile = Object.keys(files).find((f) =>
-      f.startsWith(`${configPath}.backup-`)
-    );
+    const backupFile = Object.keys(files).find((f) => f.startsWith(`${configPath}.backup-`));
     expect(backupFile).toBeDefined();
     const backupContent = await mockFsObj.readFile(backupFile!, "utf8");
     expect(backupContent).toBe("legacy-config");
-    await expect(
-      mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")
-    ).rejects.toThrow();
+    await expect(mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")).rejects.toThrow();
   });
 
   it("merges codex configuration with existing content", async () => {
     await mockFsObj.mkdir(configDir, { recursive: true });
     await mockFsObj.writeFile(
       configPath,
-      ['model_provider = "legacy"', "", "[features]", "foo = true", ""].join(
-        "\n"
-      ),
+      ['model_provider = "legacy"', "", "[features]", "foo = true", ""].join("\n"),
       { encoding: "utf8" }
     );
 
@@ -777,8 +748,7 @@ describe("codex service", () => {
     expect(doc["features"]).toEqual({ foo: true });
 
     const profiles = doc["profiles"] as Record<string, Record<string, unknown>>;
-    const defaultProfileName =
-      codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
+    const defaultProfileName = codexService.deriveCodexProfileName(DEFAULT_CODEX_MODEL);
     const codexProfile = profiles[defaultProfileName];
     expect(codexProfile["model"]).toBe(stripModelNamespace(DEFAULT_CODEX_MODEL));
     expect(codexProfile["model_provider"]).toBe("poe");
@@ -796,16 +766,12 @@ describe("codex service", () => {
     });
 
     const files = mockFs.files;
-    const backupFile = Object.keys(files).find((f) =>
-      f.startsWith(`${configPath}.backup-`)
-    );
+    const backupFile = Object.keys(files).find((f) => f.startsWith(`${configPath}.backup-`));
     expect(backupFile).toBeDefined();
     const backupContent = await mockFsObj.readFile(backupFile!, "utf8");
     expect(backupContent.trim()).toContain('model_provider = "legacy"');
     expect(backupContent.trim()).toContain("[features]");
-    await expect(
-      mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")
-    ).rejects.toThrow();
+    await expect(mockFsObj.readFile(path.join(configDir, "auth.json"), "utf8")).rejects.toThrow();
   });
 
   it("runs the Codex CLI health check via runCommand when invoking the provider test", async () => {
@@ -820,9 +786,7 @@ describe("codex service", () => {
 
     expect(runCommand).toHaveBeenCalledWith(
       "codex",
-      expect.arrayContaining([
-        "exec", "Output exactly: CODEX_OK"
-      ])
+      expect.arrayContaining(["exec", "Output exactly: CODEX_OK"])
     );
   });
 
@@ -843,9 +807,7 @@ describe("codex service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      codexService.codexService.test?.(context)
-    ).resolves.toBeUndefined();
+    await expect(codexService.codexService.test?.(context)).resolves.toBeUndefined();
   });
 
   it("includes stdout and stderr when the health check command fails", async () => {
@@ -856,9 +818,7 @@ describe("codex service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(codexService.codexService.test?.(context)).rejects.toThrow(
-      /FAIL_STDOUT/
-    );
+    await expect(codexService.codexService.test?.(context)).rejects.toThrow(/FAIL_STDOUT/);
   });
 
   it("includes stdout and stderr when the health check output is unexpected", async () => {
@@ -869,9 +829,7 @@ describe("codex service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(codexService.codexService.test?.(context)).rejects.toThrow(
-      /CODEX_OK/
-    );
+    await expect(codexService.codexService.test?.(context)).rejects.toThrow(/CODEX_OK/);
   });
 });
 
@@ -927,22 +885,16 @@ describe("kimi service", () => {
     return { context, logs };
   }
 
-  type ConfigureOptions = Parameters<
-    typeof kimiService.kimiService.configure
-  >[0]["options"];
+  type ConfigureOptions = Parameters<typeof kimiService.kimiService.configure>[0]["options"];
 
-  const buildConfigureOptions = (
-    overrides: Partial<ConfigureOptions> = {}
-  ): ConfigureOptions => ({
+  const buildConfigureOptions = (overrides: Partial<ConfigureOptions> = {}): ConfigureOptions => ({
     env,
     apiKey: "sk-test",
     model: DEFAULT_KIMI_MODEL,
     ...overrides
   });
 
-  type UnconfigureOptions = Parameters<
-    typeof kimiService.kimiService.unconfigure
-  >[0]["options"];
+  type UnconfigureOptions = Parameters<typeof kimiService.kimiService.unconfigure>[0]["options"];
 
   const buildUnconfigureOptions = (
     overrides: Partial<UnconfigureOptions> = {}
@@ -951,9 +903,7 @@ describe("kimi service", () => {
     ...overrides
   });
 
-  async function configureKimi(
-    overrides: Partial<ConfigureOptions> = {}
-  ): Promise<void> {
+  async function configureKimi(overrides: Partial<ConfigureOptions> = {}): Promise<void> {
     await kimiService.kimiService.configure({
       fs: mockFsObj,
       env,
@@ -962,9 +912,7 @@ describe("kimi service", () => {
     });
   }
 
-  async function unconfigureKimi(
-    overrides: Partial<UnconfigureOptions> = {}
-  ): Promise<boolean> {
+  async function unconfigureKimi(overrides: Partial<UnconfigureOptions> = {}): Promise<boolean> {
     return kimiService.kimiService.unconfigure({
       fs: mockFsObj,
       env,
@@ -1173,9 +1121,7 @@ describe("kimi service", () => {
 
     expect(runCommand).toHaveBeenCalledWith(
       "kimi",
-      expect.arrayContaining([
-        "-p", "Output exactly: KIMI_OK"
-      ])
+      expect.arrayContaining(["-p", "Output exactly: KIMI_OK"])
     );
   });
 
@@ -1196,9 +1142,7 @@ describe("kimi service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      kimiService.kimiService.test?.(context)
-    ).rejects.toThrow(/KIMI_FAIL_STDOUT/);
+    await expect(kimiService.kimiService.test?.(context)).rejects.toThrow(/KIMI_FAIL_STDOUT/);
   });
 
   it("includes stdout and stderr when the Kimi health check output is unexpected", async () => {
@@ -1209,9 +1153,7 @@ describe("kimi service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      kimiService.kimiService.test?.(context)
-    ).rejects.toThrow(/KIMI_OK/);
+    await expect(kimiService.kimiService.test?.(context)).rejects.toThrow(/KIMI_OK/);
   });
 
   it("removes the Poe provider from config on remove", async () => {
@@ -1237,8 +1179,7 @@ describe("opencode service", () => {
   const authPath = path.join(homeDir, ".local", "share", "opencode", "auth.json");
   let env = createCliEnvironment({ cwd: homeDir, homeDir });
 
-  const withProviderPrefix = (model: string): string =>
-    `${PROVIDER_NAME}/${model}`;
+  const withProviderPrefix = (model: string): string => `${PROVIDER_NAME}/${model}`;
 
   const DEFAULT_PROVIDER_MODEL = withProviderPrefix(DEFAULT_FRONTIER_MODEL);
 
@@ -1283,18 +1224,14 @@ describe("opencode service", () => {
     typeof opencodeService.openCodeService.configure
   >[0]["options"];
 
-  const buildConfigureOptions = (
-    overrides: Partial<ConfigureOptions> = {}
-  ): ConfigureOptions => ({
+  const buildConfigureOptions = (overrides: Partial<ConfigureOptions> = {}): ConfigureOptions => ({
     env,
     apiKey: "sk-test",
     model: DEFAULT_FRONTIER_MODEL,
     ...overrides
   });
 
-  async function configureOpenCode(
-    overrides: Partial<ConfigureOptions> = {}
-  ): Promise<void> {
+  async function configureOpenCode(overrides: Partial<ConfigureOptions> = {}): Promise<void> {
     await opencodeService.openCodeService.configure({
       fs: mockFsObj,
       env,
@@ -1331,8 +1268,7 @@ describe("opencode service", () => {
   });
 
   it("offers Gemini 3.1 Pro in configure prompts instead of the removed Gemini 3 Pro", () => {
-    const choices =
-      opencodeService.openCodeService.configurePrompts?.model?.choices ?? [];
+    const choices = opencodeService.openCodeService.configurePrompts?.model?.choices ?? [];
     const values = choices.map((choice) => choice.value);
 
     expect(values).toContain("google/gemini-3.1-pro");
@@ -1550,9 +1486,7 @@ describe("opencode service", () => {
 
     expect(runCommand).toHaveBeenCalledWith(
       "opencode",
-      expect.arrayContaining([
-        "run", "Output exactly: OPEN_CODE_OK"
-      ])
+      expect.arrayContaining(["run", "Output exactly: OPEN_CODE_OK"])
     );
   });
 
@@ -1573,9 +1507,9 @@ describe("opencode service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      opencodeService.openCodeService.test?.(context)
-    ).rejects.toThrow(/OPEN_FAIL_STDOUT/);
+    await expect(opencodeService.openCodeService.test?.(context)).rejects.toThrow(
+      /OPEN_FAIL_STDOUT/
+    );
   });
 
   it("includes stdout and stderr when the OpenCode health check output is unexpected", async () => {
@@ -1586,9 +1520,240 @@ describe("opencode service", () => {
     });
     const { context } = createProviderTestContext(runCommand);
 
-    await expect(
-      opencodeService.openCodeService.test?.(context)
-    ).rejects.toThrow(/OPEN_CODE_OK/);
+    await expect(opencodeService.openCodeService.test?.(context)).rejects.toThrow(/OPEN_CODE_OK/);
+  });
+});
+
+describe("goose service", () => {
+  let mockFsObj: FileSystem;
+  const home = "/home/user";
+  const configPath = path.join(home, ".config", "goose", "config.yaml");
+  const secretsPath = path.join(home, ".config", "goose", "secrets.yaml");
+  const providerPath = path.join(home, ".config", "goose", "custom_providers", "custom_poe.json");
+  let env = createCliEnvironment({
+    cwd: home,
+    homeDir: home
+  });
+
+  beforeEach(() => {
+    mockFsObj = createMockFs({}, home);
+    env = createCliEnvironment({
+      cwd: home,
+      homeDir: home
+    });
+  });
+
+  function createProviderTestContext(
+    runCommand: ReturnType<typeof vi.fn>,
+    options: { dryRun?: boolean } = {}
+  ): { context: ProviderContext; logs: string[] } {
+    const logs: string[] = [];
+    const logger = createLoggerFactory((message) => {
+      logs.push(message);
+    }).create({
+      dryRun: options.dryRun ?? false,
+      verbose: true,
+      scope: "test:goose"
+    });
+
+    const context = {
+      env,
+      command: {
+        runCommand,
+        fs: mockFsObj
+      },
+      logger,
+      async runCheck(check) {
+        await check.run({
+          isDryRun: logger.context.dryRun,
+          runCommand,
+          logDryRun: (message) => logger.dryRun(message)
+        });
+      }
+    } satisfies ProviderContext;
+
+    return { context, logs };
+  }
+
+  type ConfigureOptions = Parameters<typeof gooseService.gooseService.configure>[0]["options"];
+
+  const buildConfigureOptions = (overrides: Partial<ConfigureOptions> = {}): ConfigureOptions => ({
+    env,
+    apiKey: "sk-goose",
+    model: DEFAULT_GOOSE_MODEL,
+    ...overrides
+  });
+
+  async function configureGoose(overrides: Partial<ConfigureOptions> = {}): Promise<void> {
+    await gooseService.gooseService.configure({
+      fs: mockFsObj,
+      env,
+      command: createTestCommandContext(mockFsObj),
+      options: buildConfigureOptions(overrides)
+    });
+  }
+
+  it("creates the goose config, secrets, and custom provider files", async () => {
+    await configureGoose();
+
+    const config = parseYaml(await mockFsObj.readFile(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(config.GOOSE_DISABLE_KEYRING).toBe(true);
+    expect(config.GOOSE_PROVIDER).toBe("custom_poe");
+    expect(config.GOOSE_MODEL).toBe(DEFAULT_GOOSE_MODEL);
+    expect((config.extensions as Record<string, unknown>).developer).toBeDefined();
+    expect((config.extensions as Record<string, unknown>).summon).toBeDefined();
+
+    const secrets = parseYaml(await mockFsObj.readFile(secretsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(secrets.CUSTOM_POE_API_KEY).toBe("sk-goose");
+
+    const provider = JSON.parse(await mockFsObj.readFile(providerPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(provider.name).toBe("custom_poe");
+    expect(provider.base_url).toBe("https://api.poe.com/v1/chat/completions");
+    expect(provider.models).toEqual(
+      GOOSE_MODELS.map((name) => ({
+        name,
+        context_limit: 128000
+      }))
+    );
+  });
+
+  it("merges existing goose config and preserves unrelated settings", async () => {
+    await mockFsObj.mkdir(path.dirname(configPath), { recursive: true });
+    await mockFsObj.writeFile(
+      configPath,
+      ["theme: dark", "extensions:", "  custom:", "    enabled: true"].join("\n"),
+      { encoding: "utf8" }
+    );
+
+    await configureGoose({ model: FRONTIER_MODELS[FRONTIER_MODELS.length - 1]! });
+
+    const config = parseYaml(await mockFsObj.readFile(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(config.theme).toBe("dark");
+    expect(config.GOOSE_MODEL).toBe(FRONTIER_MODELS[FRONTIER_MODELS.length - 1]!);
+    expect(
+      ((config.extensions as Record<string, unknown>).custom as Record<string, unknown>).enabled
+    ).toBe(true);
+  });
+
+  it("removes managed Goose provider artifacts during unconfigure", async () => {
+    await configureGoose();
+
+    const changed = await gooseService.gooseService.unconfigure({
+      fs: mockFsObj,
+      env,
+      command: createTestCommandContext(mockFsObj),
+      options: {}
+    });
+
+    expect(changed).toBe(true);
+    const config = parseYaml(await mockFsObj.readFile(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(config.GOOSE_PROVIDER).toBeUndefined();
+    expect(config.GOOSE_MODEL).toBeUndefined();
+    await expect(mockFsObj.readFile(secretsPath, "utf8")).rejects.toThrow();
+    await expect(mockFsObj.readFile(providerPath, "utf8")).rejects.toThrow();
+  });
+
+  it("spawns Goose with provider and model flags", async () => {
+    const runCommand = vi.fn(async () => ({
+      stdout: "goose-output\n",
+      stderr: "",
+      exitCode: 0
+    }));
+    const providerContext = createProviderTestContext(runCommand).context;
+
+    const result = await gooseService.gooseService.spawn?.(providerContext, {
+      prompt: "List files",
+      model: DEFAULT_GOOSE_MODEL,
+      args: ["--session", "resume-1"]
+    });
+
+    expect(runCommand).toHaveBeenCalledWith("goose", [
+      "run",
+      "--provider",
+      "custom_poe",
+      "--model",
+      DEFAULT_GOOSE_MODEL,
+      "--output-format",
+      "text",
+      "--text",
+      "List files",
+      "--session",
+      "resume-1"
+    ]);
+    expect(result).toEqual({
+      stdout: "goose-output\n",
+      stderr: "",
+      exitCode: 0
+    });
+  });
+
+  it("uses stdin mode for Goose when requested", async () => {
+    const runCommand = vi.fn(async () => ({
+      stdout: "goose-output\n",
+      stderr: "",
+      exitCode: 0
+    }));
+    const providerContext = createProviderTestContext(runCommand).context;
+
+    await gooseService.gooseService.spawn?.(providerContext, {
+      prompt: "Read from stdin",
+      useStdin: true
+    });
+
+    expect(runCommand).toHaveBeenCalledWith(
+      "goose",
+      [
+        "run",
+        "--provider",
+        "custom_poe",
+        "--model",
+        DEFAULT_GOOSE_MODEL,
+        "--output-format",
+        "text",
+        "--instructions",
+        "-"
+      ],
+      {
+        stdin: "Read from stdin"
+      }
+    );
+  });
+
+  it("runs the Goose health check via goose run", async () => {
+    const runCommand = vi.fn().mockResolvedValue({
+      stdout: "GOOSE_OK\n",
+      stderr: "",
+      exitCode: 0
+    });
+    const { context } = createProviderTestContext(runCommand);
+
+    await gooseService.gooseService.test?.(context);
+
+    expect(runCommand).toHaveBeenCalledWith(
+      "goose",
+      expect.arrayContaining([
+        "run",
+        "--provider",
+        "custom_poe",
+        "--text",
+        "Reply with exactly: GOOSE_OK"
+      ])
+    );
   });
 });
 
@@ -1599,10 +1764,7 @@ describe("poe-agent provider", () => {
     disposeMock.mockReset();
 
     sendMessageMock.mockImplementation(
-      async (
-        _prompt: string,
-        options?: { onSessionUpdate?: (update: unknown) => void }
-      ) => {
+      async (_prompt: string, options?: { onSessionUpdate?: (update: unknown) => void }) => {
         options?.onSessionUpdate?.({
           sessionUpdate: "tool_call",
           toolCallId: "tool-1",
@@ -1694,16 +1856,15 @@ describe("poe-agent provider", () => {
     expect(newSessionSpy).toHaveBeenCalledTimes(1);
     expect(newSessionSpy).toHaveBeenCalledWith("/workspace/project", []);
     expect(promptSpy).toHaveBeenCalledTimes(1);
-    expect(promptSpy).toHaveBeenCalledWith(
-      expect.any(String),
-      [{ type: "text", text: "Summarize this diff" }]
-    );
-    expect(
-      initializeSpy.mock.invocationCallOrder[0]
-    ).toBeLessThan(newSessionSpy.mock.invocationCallOrder[0]);
-    expect(
+    expect(promptSpy).toHaveBeenCalledWith(expect.any(String), [
+      { type: "text", text: "Summarize this diff" }
+    ]);
+    expect(initializeSpy.mock.invocationCallOrder[0]).toBeLessThan(
       newSessionSpy.mock.invocationCallOrder[0]
-    ).toBeLessThan(promptSpy.mock.invocationCallOrder[0]);
+    );
+    expect(newSessionSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      promptSpy.mock.invocationCallOrder[0]
+    );
     expect(sendMessageMock).toHaveBeenCalledWith(
       "Summarize this diff",
       expect.objectContaining({
@@ -1748,21 +1909,21 @@ describe("poe-agent provider", () => {
 
     expect(createAgentSessionMock).toHaveBeenCalledWith({
       model: DEFAULT_FRONTIER_MODEL,
-      cwd: process.cwd(),
+      cwd: process.cwd()
     });
   });
 
   it("forwards baseUrl override to createAgentSession", async () => {
     const { done } = spawnPoeAgentWithAcp({
       prompt: "Explain this function",
-      baseUrl: "http://proxy.example.com/v1",
+      baseUrl: "http://proxy.example.com/v1"
     });
     await done;
 
     expect(createAgentSessionMock).toHaveBeenCalledWith({
       model: DEFAULT_FRONTIER_MODEL,
       cwd: process.cwd(),
-      baseUrl: "http://proxy.example.com/v1",
+      baseUrl: "http://proxy.example.com/v1"
     });
   });
 });
@@ -1781,8 +1942,8 @@ describe("determine provider workflow script", () => {
         typeof content === "string"
           ? content
           : Buffer.isBuffer(content)
-          ? content.toString("utf8")
-          : String(content);
+            ? content.toString("utf8")
+            : String(content);
       writes.push(text);
     }) as typeof fs.appendFileSync;
     process.env.GITHUB_OUTPUT = "/tmp/output";

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -1528,7 +1528,6 @@ describe("goose service", () => {
   let mockFsObj: FileSystem;
   const home = "/home/user";
   const configPath = path.join(home, ".config", "goose", "config.yaml");
-  const secretsPath = path.join(home, ".config", "goose", "secrets.yaml");
   const providerPath = path.join(home, ".config", "goose", "custom_providers", "custom_poe.json");
   let env = createCliEnvironment({
     cwd: home,
@@ -1593,24 +1592,15 @@ describe("goose service", () => {
     });
   }
 
-  it("creates the goose config, secrets, and custom provider files", async () => {
+  it("creates the goose config and custom provider files", async () => {
     await configureGoose();
 
     const config = parseYaml(await mockFsObj.readFile(configPath, "utf8")) as Record<
       string,
       unknown
     >;
-    expect(config.GOOSE_DISABLE_KEYRING).toBe(true);
     expect(config.GOOSE_PROVIDER).toBe("custom_poe");
     expect(config.GOOSE_MODEL).toBe(DEFAULT_GOOSE_MODEL);
-    expect((config.extensions as Record<string, unknown>).developer).toBeDefined();
-    expect((config.extensions as Record<string, unknown>).summon).toBeDefined();
-
-    const secrets = parseYaml(await mockFsObj.readFile(secretsPath, "utf8")) as Record<
-      string,
-      unknown
-    >;
-    expect(secrets.CUSTOM_POE_API_KEY).toBe("sk-goose");
 
     const provider = JSON.parse(await mockFsObj.readFile(providerPath, "utf8")) as Record<
       string,
@@ -1618,12 +1608,7 @@ describe("goose service", () => {
     >;
     expect(provider.name).toBe("custom_poe");
     expect(provider.base_url).toBe("https://api.poe.com/v1/chat/completions");
-    expect(provider.models).toEqual(
-      GOOSE_MODELS.map((name) => ({
-        name,
-        context_limit: 128000
-      }))
-    );
+    expect(provider.models).toEqual(GOOSE_MODELS);
   });
 
   it("merges existing goose config and preserves unrelated settings", async () => {
@@ -1647,8 +1632,52 @@ describe("goose service", () => {
     ).toBe(true);
   });
 
+  it("writes the custom provider against the configured Poe API base URL", async () => {
+    env = createCliEnvironment({
+      cwd: home,
+      homeDir: home,
+      variables: {
+        POE_BASE_URL: "https://proxy.example.test/gateway"
+      }
+    });
+
+    await configureGoose();
+
+    const provider = JSON.parse(await mockFsObj.readFile(providerPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(provider.base_url).toBe("https://proxy.example.test/gateway/v1/chat/completions");
+  });
+
   it("removes managed Goose provider artifacts during unconfigure", async () => {
     await configureGoose();
+
+    const changed = await gooseService.gooseService.unconfigure({
+      fs: mockFsObj,
+      env,
+      command: createTestCommandContext(mockFsObj),
+      options: {}
+    });
+
+    expect(changed).toBe(true);
+    await expect(mockFsObj.readFile(configPath, "utf8")).rejects.toThrow();
+    await expect(mockFsObj.readFile(providerPath, "utf8")).rejects.toThrow();
+  });
+
+  it("only prunes Goose YAML settings when the active provider is Poe-managed", async () => {
+    await mockFsObj.mkdir(path.dirname(configPath), { recursive: true });
+    await mockFsObj.mkdir(path.dirname(providerPath), { recursive: true });
+    await mockFsObj.writeFile(
+      configPath,
+      ["GOOSE_PROVIDER: openai", "GOOSE_MODEL: openai/gpt-5.4", "theme: dark"].join("\n"),
+      { encoding: "utf8" }
+    );
+    await mockFsObj.writeFile(
+      providerPath,
+      `${JSON.stringify(buildCustomProviderFixture(), null, 2)}\n`,
+      { encoding: "utf8" }
+    );
 
     const changed = await gooseService.gooseService.unconfigure({
       fs: mockFsObj,
@@ -1662,9 +1691,9 @@ describe("goose service", () => {
       string,
       unknown
     >;
-    expect(config.GOOSE_PROVIDER).toBeUndefined();
-    expect(config.GOOSE_MODEL).toBeUndefined();
-    await expect(mockFsObj.readFile(secretsPath, "utf8")).rejects.toThrow();
+    expect(config.GOOSE_PROVIDER).toBe("openai");
+    expect(config.GOOSE_MODEL).toBe("openai/gpt-5.4");
+    expect(config.theme).toBe("dark");
     await expect(mockFsObj.readFile(providerPath, "utf8")).rejects.toThrow();
   });
 
@@ -1746,16 +1775,30 @@ describe("goose service", () => {
 
     expect(runCommand).toHaveBeenCalledWith(
       "goose",
-      expect.arrayContaining([
+      [
         "run",
-        "--provider",
-        "custom_poe",
         "--text",
-        "Reply with exactly: GOOSE_OK"
-      ])
+        "Reply with exactly: GOOSE_OK",
+        "--output-format",
+        "text"
+      ]
     );
   });
 });
+
+function buildCustomProviderFixture(): Record<string, unknown> {
+  return {
+    name: "custom_poe",
+    engine: "openai",
+    display_name: "Poe",
+    description: "Poe OpenAI-compatible API",
+    api_key_env: "CUSTOM_POE_API_KEY",
+    base_url: "https://api.poe.com/v1/chat/completions",
+    models: GOOSE_MODELS,
+    supports_streaming: true,
+    requires_auth: true
+  };
+}
 
 describe("poe-agent provider", () => {
   beforeEach(() => {

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -263,7 +263,7 @@ describe("claude-code service", () => {
       env: {
         ANTHROPIC_BASE_URL: "https://api.poe.com"
       },
-      model: stripModelNamespace(CLAUDE_MODEL_SONNET)
+      model: stripModelNamespace(CLAUDE_MODEL_SONNET).replaceAll(".", "-")
     });
   });
 
@@ -283,7 +283,7 @@ describe("claude-code service", () => {
       env: {
         ANTHROPIC_BASE_URL: "https://proxy.example.com"
       },
-      model: stripModelNamespace(CLAUDE_MODEL_SONNET)
+      model: stripModelNamespace(CLAUDE_MODEL_SONNET).replaceAll(".", "-")
     });
   });
 
@@ -317,7 +317,7 @@ describe("claude-code service", () => {
         ANTHROPIC_BASE_URL: "https://api.poe.com",
         CUSTOM: "value"
       },
-      model: stripModelNamespace(CLAUDE_MODEL_SONNET)
+      model: stripModelNamespace(CLAUDE_MODEL_SONNET).replaceAll(".", "-")
     });
   });
 
@@ -1529,6 +1529,7 @@ describe("goose service", () => {
   const home = "/home/user";
   const configPath = path.join(home, ".config", "goose", "config.yaml");
   const providerPath = path.join(home, ".config", "goose", "custom_providers", "custom_poe.json");
+  const secretsPath = path.join(home, ".config", "goose", "secrets.yaml");
   let env = createCliEnvironment({
     cwd: home,
     homeDir: home
@@ -1580,6 +1581,7 @@ describe("goose service", () => {
     env,
     apiKey: "sk-goose",
     model: DEFAULT_GOOSE_MODEL,
+    modelContextLimits: buildGooseModelContextLimitsFixture(),
     ...overrides
   });
 
@@ -1592,7 +1594,7 @@ describe("goose service", () => {
     });
   }
 
-  it("creates the goose config and custom provider files", async () => {
+  it("creates the goose config, custom provider, and persisted secrets files", async () => {
     await configureGoose();
 
     const config = parseYaml(await mockFsObj.readFile(configPath, "utf8")) as Record<
@@ -1601,6 +1603,7 @@ describe("goose service", () => {
     >;
     expect(config.GOOSE_PROVIDER).toBe("custom_poe");
     expect(config.GOOSE_MODEL).toBe(DEFAULT_GOOSE_MODEL);
+    expect(config.GOOSE_DISABLE_KEYRING).toBe(true);
 
     const provider = JSON.parse(await mockFsObj.readFile(providerPath, "utf8")) as Record<
       string,
@@ -1608,7 +1611,17 @@ describe("goose service", () => {
     >;
     expect(provider.name).toBe("custom_poe");
     expect(provider.base_url).toBe("https://api.poe.com/v1/chat/completions");
-    expect(provider.models).toEqual(GOOSE_MODELS);
+    expect(provider.api_key_env).toBe("CUSTOM_POE_API_KEY");
+    expect(provider.headers).toEqual({ Authorization: "Bearer sk-goose" });
+    expect(provider.models).toEqual(buildCustomProviderModelsFixture());
+
+    const secrets = parseYaml(await mockFsObj.readFile(secretsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(secrets).toEqual({
+      CUSTOM_POE_API_KEY: "sk-goose"
+    });
   });
 
   it("merges existing goose config and preserves unrelated settings", async () => {
@@ -1650,6 +1663,84 @@ describe("goose service", () => {
     expect(provider.base_url).toBe("https://proxy.example.test/gateway/v1/chat/completions");
   });
 
+  it("requires explicit Goose model context limits when building the provider config", async () => {
+    await expect(configureGoose({ modelContextLimits: {} })).rejects.toThrow(
+      /Missing Goose model context limit/
+    );
+  });
+
+  it("fetches Goose model context limits from the Poe model catalog", async () => {
+    const modelContextLimits = await gooseService.gooseService.extendConfigurePayload?.({
+      fs: mockFsObj,
+      env,
+      httpClient: vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            {
+              id: "claude-opus-4.6",
+              context_window: { context_length: 983040 }
+            },
+            {
+              id: "claude-sonnet-4.6",
+              context_window: { context_length: 983040 }
+            },
+            {
+              id: "gpt-5.3-codex",
+              context_window: { context_length: 400000 }
+            },
+            {
+              id: "gpt-5.4",
+              context_window: { context_length: 1050000 }
+            },
+            {
+              id: "gemini-3.1-pro",
+              context_window: { context_length: 1048576 }
+            }
+          ]
+        })
+      })),
+      logger: createLoggerFactory(() => {}).create({
+        dryRun: false,
+        verbose: true,
+        scope: "test:goose"
+      }),
+      payload: buildConfigureOptions()
+    });
+
+    expect(modelContextLimits).toEqual({
+      modelContextLimits: buildGooseModelContextLimitsFixture()
+    });
+  });
+
+  it("fails when the Poe model catalog response is incomplete", async () => {
+    await expect(
+      gooseService.gooseService.extendConfigurePayload?.({
+        fs: mockFsObj,
+        env,
+        httpClient: vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              {
+                id: "claude-opus-4.6",
+                context_window: { context_length: 983040 }
+              }
+            ]
+          })
+        })),
+        logger: createLoggerFactory(() => {}).create({
+          dryRun: false,
+          verbose: true,
+          scope: "test:goose"
+        }),
+        payload: buildConfigureOptions()
+      })
+    ).rejects.toThrow(/Missing Goose model context limit/);
+  });
+
   it("removes managed Goose provider artifacts during unconfigure", async () => {
     await configureGoose();
 
@@ -1663,6 +1754,7 @@ describe("goose service", () => {
     expect(changed).toBe(true);
     await expect(mockFsObj.readFile(configPath, "utf8")).rejects.toThrow();
     await expect(mockFsObj.readFile(providerPath, "utf8")).rejects.toThrow();
+    await expect(mockFsObj.readFile(secretsPath, "utf8")).rejects.toThrow();
   });
 
   it("only prunes Goose YAML settings when the active provider is Poe-managed", async () => {
@@ -1670,12 +1762,17 @@ describe("goose service", () => {
     await mockFsObj.mkdir(path.dirname(providerPath), { recursive: true });
     await mockFsObj.writeFile(
       configPath,
-      ["GOOSE_PROVIDER: openai", "GOOSE_MODEL: openai/gpt-5.4", "theme: dark"].join("\n"),
+      ["GOOSE_PROVIDER: openai", "GOOSE_MODEL: openai/gpt-5.4", "GOOSE_DISABLE_KEYRING: true", "theme: dark"].join("\n"),
       { encoding: "utf8" }
     );
     await mockFsObj.writeFile(
       providerPath,
       `${JSON.stringify(buildCustomProviderFixture(), null, 2)}\n`,
+      { encoding: "utf8" }
+    );
+    await mockFsObj.writeFile(
+      secretsPath,
+      ["CUSTOM_POE_API_KEY: sk-goose", "OPENAI_API_KEY: openai-key"].join("\n"),
       { encoding: "utf8" }
     );
 
@@ -1695,6 +1792,13 @@ describe("goose service", () => {
     expect(config.GOOSE_MODEL).toBe("openai/gpt-5.4");
     expect(config.theme).toBe("dark");
     await expect(mockFsObj.readFile(providerPath, "utf8")).rejects.toThrow();
+    const secrets = parseYaml(await mockFsObj.readFile(secretsPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(secrets).toEqual({
+      OPENAI_API_KEY: "openai-key"
+    });
   });
 
   it("spawns Goose with provider and model flags", async () => {
@@ -1794,9 +1898,26 @@ function buildCustomProviderFixture(): Record<string, unknown> {
     description: "Poe OpenAI-compatible API",
     api_key_env: "CUSTOM_POE_API_KEY",
     base_url: "https://api.poe.com/v1/chat/completions",
-    models: GOOSE_MODELS,
+    models: buildCustomProviderModelsFixture(),
     supports_streaming: true,
     requires_auth: true
+  };
+}
+
+function buildCustomProviderModelsFixture(): Array<Record<string, unknown>> {
+  return GOOSE_MODELS.map((name) => ({
+    name,
+    context_limit: buildGooseModelContextLimitsFixture()[name]
+  }));
+}
+
+function buildGooseModelContextLimitsFixture(): Record<string, number> {
+  return {
+    "anthropic/claude-opus-4.6": 983040,
+    "anthropic/claude-sonnet-4.6": 983040,
+    "openai/gpt-5.3-codex": 400000,
+    "openai/gpt-5.4": 1050000,
+    "google/gemini-3.1-pro": 1048576
   };
 }
 


### PR DESCRIPTION
## Summary
- Goose custom provider now fetches model context window sizes from `/v1/models` during configure and embeds them in the provider JSON
- API key is stored in `~/.config/goose/secrets.yaml` instead of relying on env-only injection
- Isolated env switches to `HOME`/`XDG_CONFIG_HOME` for proper Goose config discovery
- Adds `extendConfigurePayload` hook to the provider interface for async pre-configure data fetching
- Fixes pre-existing login-mcp test that wasn't aligned with dot-to-dash model name transform

## Test plan
- [x] Unit tests for context limit fetching and extraction
- [x] Unit tests for secrets.yaml generation during configure
- [x] Unit test for failure when API doesn't return required context lengths
- [x] Integration test for isolated env routing (HOME/XDG_CONFIG_HOME)
- [ ] E2E test for full install → configure → test flow (in Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)