### PR TITLE
fix(providers): treat api-key env var as logged-in state

### DIFF
--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -79,4 +79,38 @@ describe("ProviderRegistry", () => {
     const registry = new ProviderRegistry([poe]);
     await expect(registry.logout("nope")).rejects.toThrow(/unknown provider/i);
   });
+
+  it("isLoggedIn returns true when api-key env var is set even if store is empty", async () => {
+    const emptyStore = {
+      get: async () => null,
+      set: async () => undefined,
+      delete: async () => undefined
+    };
+    const registry = new ProviderRegistry([poe], () => emptyStore, {
+      envVars: { POE_API_KEY: "env-key" }
+    });
+    await expect(registry.isLoggedIn("poe")).resolves.toBe(true);
+  });
+
+  it("isLoggedIn ignores whitespace-only env var values", async () => {
+    const emptyStore = {
+      get: async () => null,
+      set: async () => undefined,
+      delete: async () => undefined
+    };
+    const registry = new ProviderRegistry([poe], () => emptyStore, {
+      envVars: { POE_API_KEY: "   " }
+    });
+    await expect(registry.isLoggedIn("poe")).resolves.toBe(false);
+  });
+
+  it("isLoggedIn returns true when store has credential and env var is unset", async () => {
+    const store = {
+      get: async () => "stored-key",
+      set: async () => undefined,
+      delete: async () => undefined
+    };
+    const registry = new ProviderRegistry([poe], () => store);
+    await expect(registry.isLoggedIn("poe")).resolves.toBe(true);
+  });
 });

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -11,12 +11,21 @@ export interface LoginContext {
 
 export type ProviderStoreFactory = (providerId: string) => SecretStore;
 
+export interface ProviderRegistryOptions {
+  envVars?: Record<string, string | undefined>;
+}
+
 export class ProviderRegistry {
   private readonly providers: readonly AuthProvider[];
   private readonly byId: ReadonlyMap<string, AuthProvider>;
   private readonly storeFactory?: ProviderStoreFactory;
+  private readonly envVars: Record<string, string | undefined>;
 
-  constructor(providers: readonly AuthProvider[], storeFactory?: ProviderStoreFactory) {
+  constructor(
+    providers: readonly AuthProvider[],
+    storeFactory?: ProviderStoreFactory,
+    options?: ProviderRegistryOptions
+  ) {
     const byId = new Map<string, AuthProvider>();
     for (const provider of providers) {
       if (byId.has(provider.id)) {
@@ -27,6 +36,7 @@ export class ProviderRegistry {
     this.providers = providers;
     this.byId = byId;
     this.storeFactory = storeFactory;
+    this.envVars = options?.envVars ?? {};
   }
 
   list(): readonly AuthProvider[] {
@@ -44,7 +54,13 @@ export class ProviderRegistry {
   }
 
   async isLoggedIn(id: string): Promise<boolean> {
-    this.requireProvider(id);
+    const provider = this.requireProvider(id);
+    if (provider.auth.kind === "api-key") {
+      const envValue = this.envVars[provider.auth.envVar];
+      if (typeof envValue === "string" && envValue.trim().length > 0) {
+        return true;
+      }
+    }
     const store = this.requireStore(id);
     const credential = await store.get();
     return credential !== null;

--- a/src/cli/container.ts
+++ b/src/cli/container.ts
@@ -164,7 +164,9 @@ export function createCliContainer(dependencies: CliDependencies): CliContainer 
 
   const registry = createServiceRegistry();
 
-  const providerRegistry = new ProviderRegistry([poeProvider], (_id) => authStore);
+  const providerRegistry = new ProviderRegistry([poeProvider], (_id) => authStore, {
+    envVars: environment.variables
+  });
 
   const providers = getDefaultProviders().filter((adapter) => !adapter.disabled);
   for (const adapter of providers) {

--- a/src/sdk/container.ts
+++ b/src/sdk/container.ts
@@ -133,7 +133,9 @@ export function createSdkContainer(options?: SdkContainerOptions): CliContainer 
 
   const registry = createServiceRegistry();
 
-  const providerRegistry = new ProviderRegistry([poeProvider], (_id) => authStore);
+  const providerRegistry = new ProviderRegistry([poeProvider], (_id) => authStore, {
+    envVars: variables
+  });
 
   const providers = getDefaultProviders().filter((adapter) => !adapter.disabled);
   for (const adapter of providers) {


### PR DESCRIPTION
## Summary
- `poe-code configure codex --yes` in CI failed with `No logged-in providers support agent "codex"` even when `POE_API_KEY` was set (e.g. [creator_docs run 24894526706](https://github.com/poe-platform/creator_docs/actions/runs/24894526706/job/72895603597)).
- Root cause: the provider refactor added an `isLoggedIn` gate in [src/cli/commands/configure.ts:171-182](src/cli/commands/configure.ts#L171-L182) that only consulted the persistent secret store, while `ProviderRegistry.login()` already treats a set `auth.envVar` as a valid credential source. In CI no `provider login` is ever invoked, so the gate always failed.
- Fix: mirror `login()`'s contract in `isLoggedIn` — if the provider declares `auth.kind: "api-key"` and its `envVar` is set (non-whitespace), the provider is considered logged in. Env vars are plumbed through both the CLI and SDK containers.

## Test plan
- [x] Registry unit tests cover env-set, env-whitespace, and store-backed cases (`packages/providers/src/registry.test.ts`)
- [x] `npx vitest run packages/providers packages/github-workflows src/cli/commands/configure.test.ts src/cli/commands/provider.test.ts`
- [x] `npm run lint` + `npm run typecheck`
- [ ] Verify on creator_docs workflow after merge (re-trigger the failing comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)