### PR TITLE
fix(toolcraft): bundle process-runner and ship transitive npm deps

### DIFF
--- a/.github/workflows/release-toolcraft.yml
+++ b/.github/workflows/release-toolcraft.yml
@@ -49,6 +49,8 @@ jobs:
           cd ../toolcraft-openapi && npm pkg set "dependencies.toolcraft=^${NEXT}"
       - name: Build toolcraft packages and dependencies
         run: npx turbo build --filter=toolcraft-openapi...
+      - name: Verify standalone install resolves all bundled imports
+        run: npm run smoke:toolcraft-standalone
       - name: Publish toolcraft-schema
         working-directory: packages/toolcraft-schema
         run: npm publish --provenance --access public

--- a/packages/toolcraft/package.json
+++ b/packages/toolcraft/package.json
@@ -35,8 +35,8 @@
     "test": "cd ../.. && vitest run packages/toolcraft/src",
     "test:unit": "cd ../.. && vitest run packages/toolcraft/src",
     "lint": "cd ../.. && eslint packages/toolcraft/src --ext ts && tsc -p packages/toolcraft/tsconfig.json --noEmit",
-    "prepack": "node ../../scripts/manage-bundled-workspace-deps.mjs prepare . @poe-code/design-system @poe-code/agent-mcp-config @poe-code/agent-human-in-loop @poe-code/task-list @poe-code/file-lock @poe-code/agent-defs @poe-code/config-mutations tiny-mcp-client mcp-oauth auth-store",
-    "postpack": "node ../../scripts/manage-bundled-workspace-deps.mjs cleanup . @poe-code/design-system @poe-code/agent-mcp-config @poe-code/agent-human-in-loop @poe-code/task-list @poe-code/file-lock @poe-code/agent-defs @poe-code/config-mutations tiny-mcp-client mcp-oauth auth-store"
+    "prepack": "node ../../scripts/manage-bundled-workspace-deps.mjs prepare . @poe-code/design-system @poe-code/agent-mcp-config @poe-code/agent-human-in-loop @poe-code/task-list @poe-code/file-lock @poe-code/agent-defs @poe-code/config-mutations @poe-code/process-runner tiny-mcp-client mcp-oauth auth-store",
+    "postpack": "node ../../scripts/manage-bundled-workspace-deps.mjs cleanup . @poe-code/design-system @poe-code/agent-mcp-config @poe-code/agent-human-in-loop @poe-code/task-list @poe-code/file-lock @poe-code/agent-defs @poe-code/config-mutations @poe-code/process-runner tiny-mcp-client mcp-oauth auth-store"
   },
   "dependencies": {
     "@clack/core": "^1.0.0",
@@ -45,6 +45,10 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "console-table-printer": "^2.15.0",
+    "jose": "^6.1.2",
+    "jsonc-parser": "^3.3.1",
+    "mustache": "^4.2.0",
+    "smol-toml": "^1.3.0",
     "tiny-stdio-mcp-server": "^0.1.0",
     "yaml": "^2.8.2"
   },
@@ -67,6 +71,7 @@
     "@poe-code/file-lock",
     "@poe-code/agent-defs",
     "@poe-code/config-mutations",
+    "@poe-code/process-runner",
     "tiny-mcp-client",
     "mcp-oauth",
     "auth-store"
@@ -79,6 +84,7 @@
     "@poe-code/file-lock": "*",
     "@poe-code/agent-defs": "*",
     "@poe-code/config-mutations": "*",
+    "@poe-code/process-runner": "*",
     "tiny-mcp-client": "*",
     "mcp-oauth": "*",
     "auth-store": "*"

--- a/scripts/verify-toolcraft-standalone.mjs
+++ b/scripts/verify-toolcraft-standalone.mjs
@@ -105,7 +105,14 @@ function runConsumerSmoke(projectDir, tarballs) {
     [
       "--input-type=module",
       "--eval",
-      ['await import("toolcraft");', 'await import("toolcraft/human-in-loop");'].join("\n")
+      [
+        'await import("toolcraft");',
+        'await import("toolcraft/cli");',
+        'await import("toolcraft/mcp");',
+        'await import("toolcraft/mcp-proxy");',
+        'await import("toolcraft/sdk");',
+        'await import("toolcraft/human-in-loop");'
+      ].join("\n")
     ],
     { cwd: projectDir, stdio: "inherit" }
   );


### PR DESCRIPTION
## Summary

- Resolves #282: `toolcraft@0.0.12` crashed at module load because bundled `@poe-code/task-list` imported the private `@poe-code/process-runner` workspace package, which was neither in toolcraft's bundle nor on the public registry.
- Extending the standalone smoke to import every toolcraft entry point also surfaced missing transitive deps (`jose`, `jsonc-parser`, `mustache`, `smol-toml`) of bundled `mcp-oauth` / `@poe-code/config-mutations` — npm does not auto-install transitive deps for bundled packages.
- The toolcraft release workflow now runs `smoke:toolcraft-standalone` before publishing so this kind of regression cannot ship.

## Test plan
- [x] `npm run smoke:toolcraft-standalone` — passes (failed before the fix on `process-runner`, then on `jose`)
- [x] `npm run test --workspace=toolcraft` — 266 tests pass
- [x] `npm run lint --workspace=toolcraft` — clean
- [x] `npm run lint:workflows` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)