### PR TITLE
truffledog testing: fake token id workflows

### DIFF
--- a/.github/workflows/truffledog-testing-fake-token-id-a.yml
+++ b/.github/workflows/truffledog-testing-fake-token-id-a.yml
@@ -1,0 +1,13 @@
+name: truffledog testing fake token id a
+on:
+  workflow_dispatch: {}
+
+jobs:
+  dummy:
+    name: Dummy fake token id
+    runs-on: ubuntu-latest
+    env:
+      FAKE_TOKEN_ID: truffledog-testing-fake-token-id-a
+    steps:
+      - name: Print test marker
+        run: echo "truffledog testing fake token id a"

--- a/.github/workflows/truffledog-testing-fake-token-id-b.yml
+++ b/.github/workflows/truffledog-testing-fake-token-id-b.yml
@@ -1,0 +1,13 @@
+name: truffledog testing fake token id b
+on:
+  workflow_dispatch: {}
+
+jobs:
+  dummy:
+    name: Dummy fake token id
+    runs-on: ubuntu-latest
+    env:
+      FAKE_TOKEN_ID: truffledog-testing-fake-token-id-b
+    steps:
+      - name: Print test marker
+        run: echo "truffledog testing fake token id b"


### PR DESCRIPTION
Adds two inert workflow_dispatch-only dummy workflows for TruffleHog PR scan testing. The token IDs are fake test markers and are not provider-shaped secrets.