### PR TITLE
truffledog testing: fake token id workflow 2

### DIFF
--- a/.github/workflows/truffledog-testing-2.yml
+++ b/.github/workflows/truffledog-testing-2.yml
@@ -1,0 +1,13 @@
+name: truffledog testing 2
+on:
+  workflow_dispatch: {}
+
+jobs:
+  dummy:
+    name: Dummy fake token id 2
+    runs-on: ubuntu-latest
+    env:
+      FAKE_TOKEN_ID: truffledog-testing-fake-token-id-2
+    steps:
+      - name: Print test marker
+        run: echo "truffledog testing 2"


### PR DESCRIPTION
Adds one inert workflow_dispatch-only dummy workflow for TruffleHog PR scan testing. The fake token ID is a test marker and is not provider-shaped.