### PR TITLE
truffledog testing: clean PR fixture

### DIFF
--- a/.github/workflows/truffledog-clean-pr-check.yml
+++ b/.github/workflows/truffledog-clean-pr-check.yml
@@ -1,0 +1,12 @@
+name: Truffledog Clean PR Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-fixture:
+    name: Clean fixture
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm clean fixture
+        run: echo "This workflow intentionally contains no credentials."


### PR DESCRIPTION
Adds a harmless workflow fixture with no credential-shaped values so the TruffleHog PR scan can be checked on a clean PR.