### PR TITLE
[codex] ship toolcraft help renderer release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8338,7 +8338,7 @@
     },
     "packages/design-system": {
       "name": "@poe-code/design-system",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "peerDependencies": {
         "@clack/prompts": "^1.0.0",
         "chalk": "^5.3.0",
@@ -8766,7 +8766,7 @@
       }
     },
     "packages/toolcraft": {
-      "version": "0.0.1",
+      "version": "0.0.4",
       "bundleDependencies": [
         "@poe-code/design-system",
         "@poe-code/agent-mcp-config",
@@ -8802,7 +8802,7 @@
         "@poe-code/agent-human-in-loop": "*",
         "@poe-code/agent-mcp-config": "*",
         "@poe-code/config-mutations": "*",
-        "@poe-code/design-system": "^0.0.1",
+        "@poe-code/design-system": "^0.0.2",
         "@poe-code/file-lock": "*",
         "@poe-code/process-runner": "*",
         "@poe-code/task-list": "*",
@@ -8820,11 +8820,11 @@
       "dependencies": {
         "@clack/core": "^1.0.0",
         "@clack/prompts": "^1.0.0",
-        "@poe-code/design-system": "^0.0.1",
+        "@poe-code/design-system": "^0.0.2",
         "auth-store": "^0.0.1",
         "chalk": "^5.6.2",
         "console-table-printer": "^2.15.0",
-        "toolcraft": "^0.0.1",
+        "toolcraft": "^0.0.4",
         "yaml": "^2.8.2"
       },
       "bin": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poe-code/design-system",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/toolcraft-openapi/package.json
+++ b/packages/toolcraft-openapi/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@clack/core": "^1.0.0",
     "@clack/prompts": "^1.0.0",
-    "@poe-code/design-system": "^0.0.1",
-    "toolcraft": "^0.0.1",
+    "@poe-code/design-system": "^0.0.2",
+    "toolcraft": "^0.0.4",
     "auth-store": "^0.0.1",
     "chalk": "^5.6.2",
     "console-table-printer": "^2.15.0",

--- a/packages/toolcraft/package.json
+++ b/packages/toolcraft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toolcraft",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -77,7 +77,7 @@
     "auth-store"
   ],
   "optionalDependencies": {
-    "@poe-code/design-system": "^0.0.1",
+    "@poe-code/design-system": "^0.0.2",
     "@poe-code/agent-mcp-config": "*",
     "@poe-code/agent-human-in-loop": "*",
     "@poe-code/task-list": "*",

--- a/packages/toolcraft/src/cli.test.ts
+++ b/packages/toolcraft/src/cli.test.ts
@@ -799,13 +799,14 @@ describe("runCLI", () => {
         deploy --service <value>
         approvals  Inspect and execute queued approvals.
 
-      Global options
+      Options
         --yes  Accept defaults, skip prompts
         --output <format>  Output format: rich, md, json.
         --debug  Print stack traces for unexpected errors.
       "
     `);
-    expect(output).toContain("Global options");
+    expect(output).toContain("Options");
+    expect(output).not.toContain("Global options");
     expect(output).not.toContain("--preset");
     expect(output).toContain("--yes");
     expect(output).toContain("--output <format>");
@@ -843,7 +844,7 @@ describe("runCLI", () => {
         deploy --service <value>
         approvals  Inspect and execute queued approvals.
 
-      Global options
+      Options
         --preset <path>  Load parameter defaults from a JSON file
         --yes  Accept defaults, skip prompts
         --output <format>  Output format: rich, md, json.
@@ -851,7 +852,8 @@ describe("runCLI", () => {
         --version  Show version
       "
     `);
-    expect(output).toContain("Global options");
+    expect(output).toContain("Options");
+    expect(output).not.toContain("Global options");
     expect(output).toContain("--preset <path>");
     expect(output).toContain("--version");
     expect(output).not.toContain("-h, --help");
@@ -2979,7 +2981,7 @@ describe("runCLI", () => {
         deploy
         approvals   Inspect and execute queued approvals.
 
-      Global options
+      Options
         --yes               Accept defaults, skip prompts
         --output <format>   Output format: rich, md, json.
         --debug             Print stack traces for unexpected errors.
@@ -3155,7 +3157,7 @@ describe("runCLI", () => {
         sibling     Sibling leaf
         approvals   Inspect and execute queued approvals.
 
-      Global options
+      Options
         --yes               Accept defaults, skip prompts
         --output <format>   Output format: rich, md, json.
         --debug             Print stack traces for unexpected errors.
@@ -3228,7 +3230,7 @@ describe("runCLI", () => {
         approvals                       Inspect and execute queued
                                         approvals.
 
-      Global options
+      Options
         --yes               Accept defaults, skip prompts
         --output <format>   Output format: rich, md, json.
         --debug             Print stack traces for unexpected
@@ -3268,7 +3270,7 @@ describe("runCLI", () => {
         deploy      Deploy a service
         approvals   Inspect and execute queued approvals.
 
-      Global options
+      Options
         --yes               Accept defaults, skip prompts
         --output <format>   Output format: rich, md, json.
         --debug             Print stack traces for unexpected errors.
@@ -3341,7 +3343,7 @@ describe("runCLI", () => {
     expect(dryRunCount).toBe(1);
     expect(verboseCount).toBe(1);
     expect(debugCount).toBe(1);
-    expect(rootHelp).toContain("Global options");
+    expect(rootHelp).toContain("Options");
     expect(rootHelp).toMatch(/-v,\s*--verbose\s+Log the request line to stderr/);
     expect(rootHelp).toMatch(/--debug\s+Print stack traces for unexpected errors/);
 

--- a/packages/toolcraft/src/cli.ts
+++ b/packages/toolcraft/src/cli.ts
@@ -1522,7 +1522,7 @@ function renderGroupHelp<TServices extends object>(
       ...collectSchemaGlobalFieldRows(group, scope, casing, globalLongOptionFlags)
     ];
     sections.push(
-      `${text.sectionHeader("Global options")}\n${formatHelpOptionList(globalRows)}`
+      `${text.sectionHeader("Options")}\n${formatHelpOptionList(globalRows)}`
     );
   }
 


### PR DESCRIPTION
## Summary

- Bump `@poe-code/design-system` metadata to `0.0.2` and checked-in `toolcraft` metadata to `0.0.4`.
- Align `toolcraft-openapi` workspace dependency ranges with the bumped design-system/toolcraft metadata so `npm ci` can resolve local workspaces.
- Change generated root help from `Global options` to `Options`, keeping commander `-h, --help` out of generated option rows.
- Update focused CLI help snapshots/assertions for the new output.

## Validation

- `npm run build -w @poe-code/design-system`
- `npm run build -w toolcraft`
- `npm run test -w toolcraft -- packages/toolcraft/src/cli.test.ts packages/toolcraft/src/renderer.test.ts`
- `npm ci --ignore-scripts --no-audit --no-fund` in a clean worktree
- GitHub trusted-publishing workflow run `25862723867`
- ashby smoke against published `toolcraft@0.0.16`: root/calendar help commands plus `todo lists --yes`

## Release note

Trusted publishing ran from GitHub Actions and published `toolcraft`, `toolcraft-schema`, and `toolcraft-openapi` at `0.0.16`. I did not publish from local.
