### PR TITLE
fix(agent-script): prevent Object globals from mutating host prototypes

### DIFF
--- a/packages/agent-script/src/interp/globals/object-array.test.ts
+++ b/packages/agent-script/src/interp/globals/object-array.test.ts
@@ -102,6 +102,27 @@ describe("createObjectArrayGlobals", () => {
     await expect(getClosure(getProperty(globals.Array, "from")).call(["10", globals.Number])).resolves.toEqual([1, 0]);
   });
 
+
+  it("blocks assign and freeze on host prototype objects", async () => {
+    const globals = createObjectArrayGlobals({
+      budget: new Budget()
+    });
+
+    expect(() =>
+      getClosure(getProperty(globals.Object, "assign")).call([
+        Object.prototype as unknown as SandboxObject,
+        {
+          polluted: true
+        }
+      ])
+    ).toThrowError("Object.assign(target, ...sources) requires an object or array target.");
+
+    expect(await getClosure(getProperty(globals.Object, "freeze")).call([Object.prototype as unknown as SandboxObject])).toBe(
+      Object.prototype
+    );
+    expect(Object.isFrozen(Object.prototype)).toBe(false);
+  });
+
   it("treats sandbox coercion helpers as opaque Object sources", async () => {
     const globals = createObjectArrayGlobals({
       budget: new Budget()

--- a/packages/agent-script/src/interp/globals/object-array.ts
+++ b/packages/agent-script/src/interp/globals/object-array.ts
@@ -37,13 +37,7 @@ export function createObjectArrayGlobals(options: { budget: Budget }): ObjectArr
         name: "fromEntries"
       }),
       freeze: createSandboxClosure({
-        call: ([value]) => {
-          if (typeof value === "object" && value !== null) {
-            Object.freeze(value);
-          }
-
-          return value;
-        },
+        call: ([value]) => freezeSandboxValue(value),
         name: "freeze"
       }),
       assign: createSandboxClosure({
@@ -80,6 +74,15 @@ export function createObjectArrayGlobals(options: { budget: Budget }): ObjectArr
   };
 }
 
+function freezeSandboxValue(value: SandboxValue): SandboxValue {
+  if (!isAssignableSandboxTarget(value)) {
+    return value;
+  }
+
+  Object.freeze(value);
+  return value;
+}
+
 function assignSandboxValues(target: SandboxValue, sources: readonly SandboxValue[]): SandboxValue {
   if (target === null || target === undefined) {
     throw new TypeError("Object.assign(target, ...sources) requires a non-null target.");
@@ -105,7 +108,15 @@ function assignSandboxValues(target: SandboxValue, sources: readonly SandboxValu
 function isAssignableSandboxTarget(
   value: SandboxValue
 ): value is SandboxObject & Record<string, SandboxValue> | SandboxValue[] & Record<string, SandboxValue> {
-  return typeof value === "object" && value !== null && !isSandboxClosure(value) && !isSandboxPromise(value);
+  if (typeof value !== "object" || value === null || isSandboxClosure(value) || isSandboxPromise(value)) {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  return Object.getPrototypeOf(value) === Object.prototype;
 }
 
 async function arrayFromSandboxValues(args: readonly SandboxValue[], budget: Budget): Promise<SandboxValue> {


### PR DESCRIPTION
### Motivation
- Prevent sandboxed scripts from reaching and mutating host prototypes (for example `Object.prototype`) via the newly exposed `Object.assign`/`Object.freeze` globals, which cross the sandbox boundary and enable prototype pollution or process-wide DoS.

### Description
- Route the `Object.freeze` global through a guarded helper `freezeSandboxValue` so freezing is only applied to approved sandbox-owned targets and is a no-op for other values.
- Tighten target validation with `isAssignableSandboxTarget` so only arrays or plain objects whose prototype is `Object.prototype` (and that are not sandbox closures/promises) are considered assignable.
- Keep `Object.assign` semantics but reject non-assignable targets with a `TypeError` to prevent writes to host prototype objects.
- Add a regression test that asserts `Object.assign(Object.prototype, ...)` is rejected and `Object.freeze(Object.prototype)` is a no-op that does not freeze the host prototype.

### Testing
- Ran `npm run test:unit -- packages/agent-script/src/interp/globals/object-array.test.ts` and all tests passed (5 passed).
- Pre-commit checks (`npm run lint:eslint` and `tsc -p tsconfig.build.json --noEmit`) ran as part of the commit hook; lint produced warnings only and type check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06612e478c832ab779775710dda788)