### PR TITLE
fix(superintendent): prevent owner review from loading document MCP servers

### DIFF
--- a/packages/superintendent/src/runtime/run-owner-review.test.ts
+++ b/packages/superintendent/src/runtime/run-owner-review.test.ts
@@ -206,15 +206,10 @@ describe("runOwnerReview", () => {
     });
   });
 
-  it("propagates mcp timeout values to spawn", async () => {
+  it("ignores document-defined MCP servers during owner review", async () => {
     autonomousMock.mockImplementation(async (_, { mcpServers }) => {
-      expect(mcpServers).toMatchObject({
-        "plan-browser": {
-          command: "poe-code",
-          args: ["plan", "list"],
-          timeout: 90
-        }
-      });
+      expect(mcpServers).not.toHaveProperty("plan-browser");
+      expect(findWorkflowServer(mcpServers)).toBeDefined();
 
       return {
         toolCalls: [

--- a/packages/superintendent/src/runtime/run-owner-review.ts
+++ b/packages/superintendent/src/runtime/run-owner-review.ts
@@ -1,5 +1,5 @@
 import "@poe-code/agent-spawn/register-factories";
-import type { McpConfig, SuperintendentDoc } from "../document/parse.js";
+import type { SuperintendentDoc } from "../document/parse.js";
 import {
   runAutonomousAgent,
   type AutonomousOutput,
@@ -77,21 +77,10 @@ function buildTemplateContext(
   return { ...context, plan: { path: doc.filePath } };
 }
 
-function buildMcpServers(doc: SuperintendentDoc): McpSpawnConfig {
-  const servers: McpSpawnConfig = {
+function buildMcpServers(_doc: SuperintendentDoc): McpSpawnConfig {
+  return {
     [WORKFLOW_SERVER_NAME]: createWorkflowServer()
   };
-
-  const merged = {
-    ...(doc.frontmatter.mcp ?? {}),
-    ...(doc.frontmatter.owner.mcp ?? {})
-  };
-
-  for (const [name, config] of Object.entries(merged)) {
-    servers[name] = toSpawnMcpServer(config);
-  }
-
-  return servers;
 }
 
 function createWorkflowServer(): McpSpawnConfig[string] {
@@ -101,14 +90,6 @@ function createWorkflowServer(): McpSpawnConfig[string] {
     command: WORKFLOW_SERVER_COMMAND,
     args: [WORKFLOW_SERVER_SUBCOMMAND, encodeJson(workflowTool)],
     timeout: WORKFLOW_SERVER_TIMEOUT_SECONDS
-  };
-}
-
-function toSpawnMcpServer(config: McpConfig): McpSpawnConfig[string] {
-  return {
-    command: config.command,
-    ...(config.args ? { args: [...config.args] } : {}),
-    ...(config.timeout !== undefined ? { timeout: config.timeout } : {})
   };
 }
 


### PR DESCRIPTION
### Motivation
- Owner review previously forwarded MCP server definitions from superintendent document frontmatter into the spawned owner agent, creating a trust-boundary where attacker-controlled plans could cause local commands to be executed.

### Description
- Limit owner review MCP configuration to the built-in workflow transition server by changing `buildMcpServers` to only return the `owner-workflow` MCP server and ignore document-supplied MCP entries.
- Remove the document-to-spawn MCP mapping path and the unused `toSpawnMcpServer`/`McpConfig` usage from `packages/superintendent/src/runtime/run-owner-review.ts`.
- Update unit tests in `packages/superintendent/src/runtime/run-owner-review.test.ts` to assert that document-defined MCP servers are ignored while the workflow MCP server remains present and retains its timeout.

### Testing
- Ran `npm run test -- packages/superintendent/src/runtime/run-owner-review.test.ts` and the test file passed (13 tests all succeeding). 
- Commit hooks ran `npm run lint:eslint` and `npm run lint:types` as part of the commit and they completed (warnings only for existing files, no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06b144dcd4832a8cb7fa70b7255b9b)