### PR TITLE
[codex] remove avoidable slow test waits

### DIFF
--- a/packages/agent-eval/src/run/clone.integration.test.ts
+++ b/packages/agent-eval/src/run/clone.integration.test.ts
@@ -1,18 +1,10 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  access,
-  chmod,
-  mkdtemp,
-  mkdir,
-  readdir,
-  rm,
-  writeFile
-} from "node:fs/promises";
+import { access, cp, chmod, mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { simpleGit } from "simple-git";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { cloneTarget } from "./clone.js";
 
@@ -25,6 +17,8 @@ interface FixtureRepo {
 }
 
 let roots: string[] = [];
+let fixtureRoot: string;
+let fixtureTemplate: FixtureRepo;
 
 async function tempRoot(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), "agent-eval-clone-"));
@@ -57,6 +51,16 @@ async function createFixtureRepo(root: string): Promise<FixtureRepo> {
   return { sourceRepo, bareRepo, headSha };
 }
 
+async function copyFixtureRepo(root: string): Promise<FixtureRepo> {
+  const sourceRepo = path.join(root, "source");
+  const bareRepo = path.join(root, "fixture.git");
+  await Promise.all([
+    cp(fixtureTemplate.sourceRepo, sourceRepo, { recursive: true }),
+    cp(fixtureTemplate.bareRepo, bareRepo, { recursive: true })
+  ]);
+  return { sourceRepo, bareRepo, headSha: fixtureTemplate.headSha };
+}
+
 async function commitFixtureChange(
   sourceRepo: string,
   fileName: string,
@@ -76,6 +80,15 @@ async function expectMissing(target: string): Promise<void> {
 }
 
 describe("cloneTarget", () => {
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(path.join(tmpdir(), "agent-eval-clone-template-"));
+    fixtureTemplate = await createFixtureRepo(fixtureRoot);
+  });
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
   beforeEach(() => {
     roots = [];
   });
@@ -86,7 +99,7 @@ describe("cloneTarget", () => {
 
   it("clones a ref and returns the resolved HEAD sha", async () => {
     const root = await tempRoot();
-    const fixture = await createFixtureRepo(root);
+    const fixture = await copyFixtureRepo(root);
     const dest = path.join(root, "clone");
 
     const result = await cloneTarget({
@@ -101,7 +114,7 @@ describe("cloneTarget", () => {
 
   it("reuses a cached bare repo for repeated worktrees", async () => {
     const root = await tempRoot();
-    const fixture = await createFixtureRepo(root);
+    const fixture = await copyFixtureRepo(root);
     const cacheDir = path.join(root, "cache");
 
     await expect(
@@ -129,7 +142,7 @@ describe("cloneTarget", () => {
 
   it("fetches cached bare repos before creating later worktrees", async () => {
     const root = await tempRoot();
-    const fixture = await createFixtureRepo(root);
+    const fixture = await copyFixtureRepo(root);
     const cacheDir = path.join(root, "cache");
 
     await expect(
@@ -161,7 +174,7 @@ describe("cloneTarget", () => {
 
   it("reuses a cached destination after its previous worktree was deleted", async () => {
     const root = await tempRoot();
-    const fixture = await createFixtureRepo(root);
+    const fixture = await copyFixtureRepo(root);
     const cacheDir = path.join(root, "cache");
     const dest = path.join(root, "same-dest");
 
@@ -188,7 +201,7 @@ describe("cloneTarget", () => {
 
   it("cleans up the destination when an in-flight clone is aborted", async () => {
     const root = await tempRoot();
-    const fixture = await createFixtureRepo(root);
+    const fixture = await copyFixtureRepo(root);
     const wrapperDir = path.join(root, "bin");
     const dest = path.join(root, "aborted");
     const originalPath = process.env.PATH;
@@ -200,13 +213,13 @@ describe("cloneTarget", () => {
       path.join(wrapperDir, "git"),
       [
         "#!/bin/sh",
-        "if [ \"$1\" = \"clone\" ]; then",
-        "  dest=\"\"",
-        "  for arg in \"$@\"; do dest=\"$arg\"; done",
-        "  mkdir -p \"$dest/.git\"",
+        'if [ "$1" = "clone" ]; then',
+        '  dest=""',
+        '  for arg in "$@"; do dest="$arg"; done',
+        '  mkdir -p "$dest/.git"',
         "  sleep 2",
         "fi",
-        "exec \"$REAL_GIT\" \"$@\"",
+        'exec "$REAL_GIT" "$@"',
         ""
       ].join("\n")
     );

--- a/packages/agent-harness-tools/src/run-poe-command.test.ts
+++ b/packages/agent-harness-tools/src/run-poe-command.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@poe-code/poe-code-config";
 import type { RunHandle, RunResult, RunSpec } from "@poe-code/process-runner";
 import { createFsFromVolume, Volume } from "memfs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   DownloadResult,
   ExecutionEnvFactory,
@@ -112,15 +112,16 @@ function createMockEnv(
     },
     exec(spec): RunHandle {
       env.execSpecs.push(spec);
-      if (spec.command === "sh" && spec.args?.[0] === "-c") {
-        void writeExitFile(rawFs.promises, spec, commandExitCode);
-      }
+      const executionResult =
+        spec.command === "sh" && spec.args?.[0] === "-c"
+          ? writeExitFile(rawFs.promises, spec, commandExitCode).then(() => result)
+          : result;
       return {
         pid: 123,
         stdout: null,
         stderr: null,
         stdin: null,
-        result,
+        result: executionResult,
         kill() {}
       };
     },
@@ -255,6 +256,46 @@ describe("runPoeCommand", () => {
     });
   });
 
+  it("does not poll for a wrapped command exit file after its process completes", async () => {
+    vi.useFakeTimers();
+    const { state } = createRecordingState();
+    const env = createMockEnv();
+
+    try {
+      await expect(
+        runPoeCommand({
+          factory: createFactory(env),
+          openSpec: createOpenSpec(),
+          detach: false,
+          state
+        })
+      ).resolves.toMatchObject({ kind: "sync", exitCode: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not poll for a wrapped command exit file when cancellation remains inactive", async () => {
+    vi.useFakeTimers();
+    const { state } = createRecordingState();
+    const env = createMockEnv();
+    const controller = new AbortController();
+
+    try {
+      await expect(
+        runPoeCommand({
+          factory: createFactory(env),
+          openSpec: createOpenSpec(),
+          detach: false,
+          state,
+          signal: controller.signal
+        })
+      ).resolves.toMatchObject({ kind: "sync", exitCode: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("leaves the environment open in detach mode", async () => {
     const { state, statuses } = createRecordingState();
     const runResult = deferred<RunResult>();
@@ -373,9 +414,8 @@ describe("runPoeCommand", () => {
     };
     env.exec = (spec): RunHandle => {
       env.execSpecs.push(spec);
-      const nextIteration = remoteIterations.trim().length === 0
-        ? 1
-        : remoteIterations.trim().split("\n").length + 1;
+      const nextIteration =
+        remoteIterations.trim().length === 0 ? 1 : remoteIterations.trim().split("\n").length + 1;
       remoteIterations += `${nextIteration}\n`;
       return {
         pid: 123,

--- a/packages/agent-harness-tools/src/run-poe-command.ts
+++ b/packages/agent-harness-tools/src/run-poe-command.ts
@@ -65,7 +65,7 @@ export async function runPoeCommand(opts: {
           stdout: execution?.stdout ?? "pipe",
           stderr: execution?.stderr ?? "pipe",
           signal: opts.signal
-    });
+        });
 
     if (execution?.input !== undefined) {
       writeExecutionInput(handle, execution.input);
@@ -479,7 +479,13 @@ function createAbortSync(
 
   if (signal === undefined) {
     return {
-      waitForExit: (env, jobId) => waitForExit(toLogStreamEnv(env), jobId),
+      waitForExit: async (env, jobId) => {
+        await handle.result;
+        if (timedOut) {
+          throw createActivityTimeoutError(activityTimeoutMs!);
+        }
+        return waitForExit(toLogStreamEnv(env), jobId);
+      },
       waitForHandle: async () => {
         const result = await handle.result;
         if (timedOut) {
@@ -494,7 +500,6 @@ function createAbortSync(
     };
   }
 
-  const exitWaitController = new AbortController();
   let aborted = signal.aborted;
   const abortedPromise = new Promise<void>((resolve) => {
     notifyAbort = resolve;
@@ -517,26 +522,21 @@ function createAbortSync(
         return handle.result;
       }
 
-      const exit = waitForExit(toLogStreamEnv(env), jobId, {
-        signal: exitWaitController.signal
-      }).then(
-        (value) => ({ kind: "exit" as const, value }),
-        (error: unknown) => ({ kind: "error" as const, error })
-      );
       const result = await Promise.race([
-        exit,
+        handle.result.then((value) => ({ kind: "exit" as const, value })),
         abortedPromise.then(() => ({ kind: "abort" as const }))
       ]);
 
       if (result.kind === "exit") {
-        return result.value;
+        if (timedOut) {
+          throw createActivityTimeoutError(activityTimeoutMs!);
+        }
+        if (aborted) {
+          return result.value;
+        }
+        return waitForExit(toLogStreamEnv(env), jobId);
       }
 
-      if (result.kind === "error") {
-        throw result.error;
-      }
-
-      exitWaitController.abort();
       return handle.result;
     },
     async waitForHandle() {
@@ -563,7 +563,6 @@ function createAbortSync(
     resetActivityTimer,
     dispose() {
       if (activityTimer) clearTimeout(activityTimer);
-      exitWaitController.abort();
       signal.removeEventListener("abort", kill);
     }
   };


### PR DESCRIPTION
## What changed
- Wait for wrapped synchronous command completion before reading its generated exit artifact, rather than polling every 250ms after the wrapper is already done.
- Add regressions covering both ordinary wrapped sync execution and execution with an inactive cancellation signal.
- Reuse one prepared Git repository history in `clone.integration.test.ts`, while copying isolated source/bare repositories per test.

## Root cause
- `runPoeCommand` read wrapper exit files through a polling API even for synchronous executions whose completed wrapper process guarantees the exit file has been published.
- The clone integration suite paid real Git init/config/commit/clone setup costs independently in every test.

## Impact
- `packages/agent-harness-tools/src/run-poe-command.test.ts` test work dropped from approximately `1.78s` to `32ms` in focused profiling.
- `packages/agent-eval/src/run/clone.integration.test.ts` test work dropped from approximately `5.12s` to `2.65s` in focused profiling.
- The fixes remove real avoidable latency rather than hiding it behind higher test-runner concurrency.

## Validation
- Demonstrated new no-poll regression fails against the previous behavior by timeout, then passes after the fix.
- `npx vitest run packages/agent-eval/src/run/clone.integration.test.ts packages/agent-harness-tools/src/run-poe-command.test.ts packages/agent-harness-tools/src/log-stream.test.ts --maxWorkers=1 --reporter=dot`
- `npm test -w @poe-code/agent-eval`
- `npm run build -w @poe-code/agent-eval`
- `npm run test:unit -w @poe-code/agent-harness-tools`
- `npm run build -w @poe-code/agent-harness-tools`
- `npm run lint:eslint`
- `npm run lint:types`