### PR TITLE
fix: make code review prompt transport stdin-safe

### DIFF
--- a/docs/schemas/plans/pipeline.schema.json
+++ b/docs/schemas/plans/pipeline.schema.json
@@ -45,6 +45,9 @@
         "additionalProperties": false
       }
     },
+    "name": {
+      "type": "string"
+    },
     "setup": {
       "anyOf": [
         {
@@ -120,6 +123,9 @@
           "const": false
         }
       ]
+    },
+    "state": {
+      "type": "string"
     },
     "steps": {
       "type": "object",

--- a/packages/agent-code-review/src/mcp.test.ts
+++ b/packages/agent-code-review/src/mcp.test.ts
@@ -3,7 +3,8 @@ import { createCodeReviewState } from "./review-store.js";
 import { spawn } from "@poe-code/agent-spawn";
 import { createCodeReviewAgentMcpConfig, createCodeReviewAgentMcpGroup } from "./mcp.js";
 
-vi.mock("@poe-code/agent-spawn", () => ({
+vi.mock("@poe-code/agent-spawn", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@poe-code/agent-spawn")>()),
   spawn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }))
 }));
 
@@ -96,39 +97,43 @@ describe("createCodeReviewAgentMcpConfig", () => {
 });
 
 describe("createCodeReviewAgentMcpGroup orchestrator tools", () => {
-  it("spawns nested reviewers using stdin-safe prompt transport", async () => {
-    const state = createCodeReviewState({
-      sessionId: "session-1",
-      prUrl: "https://github.com/acme/repo/pull/1",
-      selectedAgent: "codex",
-      selectedProfiles: ["generic"]
-    });
-    const group = createCodeReviewAgentMcpGroup(
-      {
-        role: "orchestrator",
-        session: "session-1",
-        actor: "orchestrator",
-        cwd: "/repo",
-        agent: "codex"
-      },
-      {
-        store: {
-          read: vi.fn(async () => state),
-          addSubagent: vi.fn(async () => state),
-          updateSubagent: vi.fn(async () => state),
-          appendOrchestratorAction: vi.fn(async () => state)
-        } as never,
-        fetchPr: vi.fn(async () => ({}))
-      }
-    );
-    const command = group.children.find(({ name }) => name === "code_review_agent_spawn");
+  it.each(["codex", "claude-code", "claude", "CLAUDE"])(
+    "spawns %s nested reviewers using stdin-safe prompt transport",
+    async (agent) => {
+      const state = createCodeReviewState({
+        sessionId: "session-1",
+        prUrl: "https://github.com/acme/repo/pull/1",
+        selectedAgent: agent,
+        selectedProfiles: ["generic"]
+      });
+      const group = createCodeReviewAgentMcpGroup(
+        {
+          role: "orchestrator",
+          session: "session-1",
+          actor: "orchestrator",
+          cwd: "/repo",
+          agent
+        },
+        {
+          store: {
+            read: vi.fn(async () => state),
+            addSubagent: vi.fn(async () => state),
+            updateSubagent: vi.fn(async () => state),
+            appendOrchestratorAction: vi.fn(async () => state)
+          } as never,
+          fetchPr: vi.fn(async () => ({}))
+        }
+      );
+      const command = group.children.find(({ name }) => name === "code_review_agent_spawn");
 
-    await command?.handler({
-      params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
-    } as never);
-    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
-    expect(spawn).toHaveBeenCalledWith("codex", expect.objectContaining({ useStdin: true }));
-  });
+      vi.mocked(spawn).mockClear();
+      await command?.handler({
+        params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
+      } as never);
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+      expect(spawn).toHaveBeenCalledWith(agent, expect.objectContaining({ useStdin: true }));
+    }
+  );
 
   it.each(["kimi", "goose"])(
     "does not pass raw text stdin to the %s structured-input protocol",

--- a/packages/agent-code-review/src/mcp.test.ts
+++ b/packages/agent-code-review/src/mcp.test.ts
@@ -130,6 +130,44 @@ describe("createCodeReviewAgentMcpGroup orchestrator tools", () => {
     expect(spawn).toHaveBeenCalledWith("codex", expect.objectContaining({ useStdin: true }));
   });
 
+  it.each(["kimi", "goose"])(
+    "does not pass raw text stdin to the %s structured-input protocol",
+    async (agent) => {
+      const state = createCodeReviewState({
+        sessionId: "session-1",
+        prUrl: "https://github.com/acme/repo/pull/1",
+        selectedAgent: agent,
+        selectedProfiles: ["generic"]
+      });
+      const group = createCodeReviewAgentMcpGroup(
+        {
+          role: "orchestrator",
+          session: "session-1",
+          actor: "orchestrator",
+          cwd: "/repo",
+          agent
+        },
+        {
+          store: {
+            read: vi.fn(async () => state),
+            addSubagent: vi.fn(async () => state),
+            updateSubagent: vi.fn(async () => state),
+            appendOrchestratorAction: vi.fn(async () => state)
+          } as never,
+          fetchPr: vi.fn(async () => ({}))
+        }
+      );
+      const command = group.children.find(({ name }) => name === "code_review_agent_spawn");
+
+      vi.mocked(spawn).mockClear();
+      await command?.handler({
+        params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
+      } as never);
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+      expect(spawn).toHaveBeenCalledWith(agent, expect.not.objectContaining({ useStdin: true }));
+    }
+  );
+
   it("exposes local merged-draft edit, delete, and discard commands", async () => {
     const state = createCodeReviewState({
       sessionId: "session-1",

--- a/packages/agent-code-review/src/mcp.test.ts
+++ b/packages/agent-code-review/src/mcp.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCodeReviewState } from "./review-store.js";
+import { spawn } from "@poe-code/agent-spawn";
 import { createCodeReviewAgentMcpConfig, createCodeReviewAgentMcpGroup } from "./mcp.js";
+
+vi.mock("@poe-code/agent-spawn", () => ({
+  spawn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }))
+}));
 
 describe("createCodeReviewAgentMcpConfig", () => {
   it("launches the MCP server through the shipped root executable", () => {
@@ -35,8 +40,63 @@ describe("createCodeReviewAgentMcpConfig", () => {
   it.each([
     ["audit logging", { appendFailure: new Error("Store unavailable") }, "Store unavailable"],
     ["PR loading", { fetchFailure: new Error("GitHub unavailable") }, "GitHub unavailable"]
-  ])("marks %s failures as failed instead of leaving pending state", async (_label, failure, message) => {
-    const states: Array<{ status: string; error?: string }> = [];
+  ])(
+    "marks %s failures as failed instead of leaving pending state",
+    async (_label, failure, message) => {
+      const states: Array<{ status: string; error?: string }> = [];
+      const state = createCodeReviewState({
+        sessionId: "session-1",
+        prUrl: "https://github.com/acme/repo/pull/1",
+        selectedAgent: "codex",
+        selectedProfiles: ["generic"]
+      });
+      const group = createCodeReviewAgentMcpGroup(
+        {
+          role: "orchestrator",
+          session: "session-1",
+          actor: "orchestrator",
+          cwd: "/repo",
+          agent: "codex"
+        },
+        {
+          store: {
+            read: vi.fn(async () => state),
+            addSubagent: vi.fn(async (_pr, _actor, status) => {
+              states.push(status);
+              return state;
+            }),
+            updateSubagent: vi.fn(async (_pr, _actor, status) => {
+              states.push(status);
+              return state;
+            }),
+            appendOrchestratorAction: vi.fn(async () => {
+              if ("appendFailure" in failure) throw failure.appendFailure;
+              return state;
+            })
+          } as never,
+          fetchPr: vi.fn(async () => {
+            if ("fetchFailure" in failure) throw failure.fetchFailure;
+            return {};
+          })
+        }
+      );
+      const spawnCommand = group.children.find(({ name }) => name === "code_review_agent_spawn");
+
+      expect(spawnCommand).toBeDefined();
+      await expect(
+        spawnCommand?.handler({
+          params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
+        } as never)
+      ).resolves.toEqual({ actor: "generic", agent: "codex", status: "pending" });
+      await vi.waitFor(() => {
+        expect(states.at(-1)).toMatchObject({ status: "failed", error: message });
+      });
+    }
+  );
+});
+
+describe("createCodeReviewAgentMcpGroup orchestrator tools", () => {
+  it("spawns nested reviewers using stdin-safe prompt transport", async () => {
     const state = createCodeReviewState({
       sessionId: "session-1",
       prUrl: "https://github.com/acme/repo/pull/1",
@@ -54,40 +114,22 @@ describe("createCodeReviewAgentMcpConfig", () => {
       {
         store: {
           read: vi.fn(async () => state),
-          addSubagent: vi.fn(async (_pr, _actor, status) => {
-            states.push(status);
-            return state;
-          }),
-          updateSubagent: vi.fn(async (_pr, _actor, status) => {
-            states.push(status);
-            return state;
-          }),
-          appendOrchestratorAction: vi.fn(async () => {
-            if ("appendFailure" in failure) throw failure.appendFailure;
-            return state;
-          })
+          addSubagent: vi.fn(async () => state),
+          updateSubagent: vi.fn(async () => state),
+          appendOrchestratorAction: vi.fn(async () => state)
         } as never,
-        fetchPr: vi.fn(async () => {
-          if ("fetchFailure" in failure) throw failure.fetchFailure;
-          return {};
-        })
+        fetchPr: vi.fn(async () => ({}))
       }
     );
-    const spawnCommand = group.children.find(({ name }) => name === "code_review_agent_spawn");
+    const command = group.children.find(({ name }) => name === "code_review_agent_spawn");
 
-    expect(spawnCommand).toBeDefined();
-    await expect(
-      spawnCommand?.handler({
-        params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
-      } as never)
-    ).resolves.toEqual({ actor: "generic", agent: "codex", status: "pending" });
-    await vi.waitFor(() => {
-      expect(states.at(-1)).toMatchObject({ status: "failed", error: message });
-    });
+    await command?.handler({
+      params: { pr: "https://github.com/acme/repo/pull/1", profile: "generic" }
+    } as never);
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    expect(spawn).toHaveBeenCalledWith("codex", expect.objectContaining({ useStdin: true }));
   });
-});
 
-describe("createCodeReviewAgentMcpGroup orchestrator tools", () => {
   it("exposes local merged-draft edit, delete, and discard commands", async () => {
     const state = createCodeReviewState({
       sessionId: "session-1",

--- a/packages/agent-code-review/src/mcp.ts
+++ b/packages/agent-code-review/src/mcp.ts
@@ -18,6 +18,7 @@ import type {
   CodeReviewDraft,
   CodeReviewInlineComment
 } from "./review-state.js";
+import { shouldUseTextStdinForCodeReview } from "./prompt-transport.js";
 import { CodeReviewYamlStore, resolveCodeReviewStoreDirectory } from "./review-store.js";
 
 export const CODE_REVIEW_AGENT_MCP_ROLES = ["agent", "orchestrator", "subagent"] as const;
@@ -491,7 +492,11 @@ async function spawnWithPoeCode(
     mcpServers: Record<string, { command: string; args: string[] }>;
   }
 ): Promise<SpawnResult> {
-  return spawn(agent, { prompt, ...options, useStdin: true });
+  return spawn(agent, {
+    prompt,
+    ...options,
+    ...(shouldUseTextStdinForCodeReview(agent) ? { useStdin: true } : {})
+  });
 }
 
 function renderSubagentPrompt(input: {

--- a/packages/agent-code-review/src/mcp.ts
+++ b/packages/agent-code-review/src/mcp.ts
@@ -491,7 +491,7 @@ async function spawnWithPoeCode(
     mcpServers: Record<string, { command: string; args: string[] }>;
   }
 ): Promise<SpawnResult> {
-  return spawn(agent, { prompt, ...options });
+  return spawn(agent, { prompt, ...options, useStdin: true });
 }
 
 function renderSubagentPrompt(input: {

--- a/packages/agent-code-review/src/prompt-transport.ts
+++ b/packages/agent-code-review/src/prompt-transport.ts
@@ -1,0 +1,3 @@
+export function shouldUseTextStdinForCodeReview(agent: string): boolean {
+  return agent === "codex" || agent === "claude-code";
+}

--- a/packages/agent-code-review/src/prompt-transport.ts
+++ b/packages/agent-code-review/src/prompt-transport.ts
@@ -1,3 +1,6 @@
+import { getSpawnConfig } from "@poe-code/agent-spawn";
+
 export function shouldUseTextStdinForCodeReview(agent: string): boolean {
-  return agent === "codex" || agent === "claude-code";
+  const config = getSpawnConfig(agent);
+  return config?.kind === "cli" && (config.agentId === "codex" || config.agentId === "claude-code");
 }

--- a/packages/agent-code-review/src/review.test.ts
+++ b/packages/agent-code-review/src/review.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { CodeReviewYamlStore } from "./review-store.js";
 import { createCodeReviewState } from "./review-store.js";
 import { runCodeReview } from "./review.js";
+import { spawn } from "@poe-code/agent-spawn";
+
+vi.mock("@poe-code/agent-spawn", () => ({
+  spawn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }))
+}));
 
 const assetMocks = vi.hoisted(() => ({
   loadProfile: vi.fn(async () => "custom profile"),
@@ -13,11 +18,13 @@ vi.mock("./assets.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./assets.js")>();
   return {
     ...actual,
-    discoverCodeReviewProfiles: vi.fn(async () => [{
-      name: "generic",
-      content: "generic profile",
-      source: "built-in" as const
-    }]),
+    discoverCodeReviewProfiles: vi.fn(async () => [
+      {
+        name: "generic",
+        content: "generic profile",
+        source: "built-in" as const
+      }
+    ]),
     loadCodeReviewProfile: assetMocks.loadProfile,
     loadCodeReviewPrompt: assetMocks.loadPrompt
   };
@@ -66,4 +73,48 @@ describe("runCodeReview asset paths", () => {
     expect(assetMocks.loadProfile).toHaveBeenCalledWith(resolve(cwd, "profiles/security.md"));
     expect(assetMocks.loadPrompt).toHaveBeenCalledWith(resolve(cwd, "prompts/review.md"));
   });
+
+  it("pipes text-safe orchestrator prompts through stdin", async () => {
+    await runCodeReview(
+      { prUrl, cwd: "/repo/worktree" },
+      {
+        resolveOptions: async (input) => ({
+          ...input,
+          agent: "codex",
+          draftStore: ".poe-code/code-review/reviews",
+          humanGate: { provider: "none" }
+        }),
+        fetchPr: async () => ({}),
+        fetchDiff: async () => "",
+        fetchComments: async () => ({}),
+        store: createStore()
+      }
+    );
+
+    expect(spawn).toHaveBeenCalledWith("codex", expect.objectContaining({ useStdin: true }));
+  });
+
+  it.each(["kimi", "goose"])(
+    "does not pipe raw text into the %s structured-input orchestrator",
+    async (agent) => {
+      vi.mocked(spawn).mockClear();
+      await runCodeReview(
+        { prUrl, cwd: "/repo/worktree" },
+        {
+          resolveOptions: async (input) => ({
+            ...input,
+            agent,
+            draftStore: ".poe-code/code-review/reviews",
+            humanGate: { provider: "none" }
+          }),
+          fetchPr: async () => ({}),
+          fetchDiff: async () => "",
+          fetchComments: async () => ({}),
+          store: createStore()
+        }
+      );
+
+      expect(spawn).toHaveBeenCalledWith(agent, expect.not.objectContaining({ useStdin: true }));
+    }
+  );
 });

--- a/packages/agent-code-review/src/review.test.ts
+++ b/packages/agent-code-review/src/review.test.ts
@@ -5,7 +5,8 @@ import { createCodeReviewState } from "./review-store.js";
 import { runCodeReview } from "./review.js";
 import { spawn } from "@poe-code/agent-spawn";
 
-vi.mock("@poe-code/agent-spawn", () => ({
+vi.mock("@poe-code/agent-spawn", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@poe-code/agent-spawn")>()),
   spawn: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }))
 }));
 
@@ -74,25 +75,29 @@ describe("runCodeReview asset paths", () => {
     expect(assetMocks.loadPrompt).toHaveBeenCalledWith(resolve(cwd, "prompts/review.md"));
   });
 
-  it("pipes text-safe orchestrator prompts through stdin", async () => {
-    await runCodeReview(
-      { prUrl, cwd: "/repo/worktree" },
-      {
-        resolveOptions: async (input) => ({
-          ...input,
-          agent: "codex",
-          draftStore: ".poe-code/code-review/reviews",
-          humanGate: { provider: "none" }
-        }),
-        fetchPr: async () => ({}),
-        fetchDiff: async () => "",
-        fetchComments: async () => ({}),
-        store: createStore()
-      }
-    );
+  it.each(["codex", "claude-code", "claude", "CLAUDE"])(
+    "pipes %s text-safe orchestrator prompts through stdin",
+    async (agent) => {
+      vi.mocked(spawn).mockClear();
+      await runCodeReview(
+        { prUrl, cwd: "/repo/worktree" },
+        {
+          resolveOptions: async (input) => ({
+            ...input,
+            agent,
+            draftStore: ".poe-code/code-review/reviews",
+            humanGate: { provider: "none" }
+          }),
+          fetchPr: async () => ({}),
+          fetchDiff: async () => "",
+          fetchComments: async () => ({}),
+          store: createStore()
+        }
+      );
 
-    expect(spawn).toHaveBeenCalledWith("codex", expect.objectContaining({ useStdin: true }));
-  });
+      expect(spawn).toHaveBeenCalledWith(agent, expect.objectContaining({ useStdin: true }));
+    }
+  );
 
   it.each(["kimi", "goose"])(
     "does not pipe raw text into the %s structured-input orchestrator",

--- a/packages/agent-code-review/src/review.ts
+++ b/packages/agent-code-review/src/review.ts
@@ -21,6 +21,7 @@ import {
   resolveCodeReviewRuntimeOptions
 } from "./config.js";
 import { createCodeReviewAgentMcpConfig } from "./mcp.js";
+import { shouldUseTextStdinForCodeReview } from "./prompt-transport.js";
 import type { CodeReviewState } from "./review-state.js";
 import { CodeReviewYamlStore, resolveCodeReviewStoreDirectory } from "./review-store.js";
 
@@ -236,5 +237,9 @@ async function spawnWithPoeCode(
   prompt: string,
   options: Omit<SpawnOptions, "prompt">
 ): Promise<SpawnResult> {
-  return spawn(agent, { prompt, ...options });
+  return spawn(agent, {
+    prompt,
+    ...options,
+    ...(shouldUseTextStdinForCodeReview(agent) ? { useStdin: true } : {})
+  });
 }

--- a/packages/agent-spawn/src/agent-spawn.test.ts
+++ b/packages/agent-spawn/src/agent-spawn.test.ts
@@ -477,6 +477,19 @@ describe("buildSpawnArgs", () => {
     expect(result.args).not.toContain(prompt);
   });
 
+  it("uses stdin args for codex when the prompt is too large for safe argv transport", () => {
+    const prompt = "x".repeat(128 * 1024);
+    const result = buildSpawnArgs("codex", { prompt });
+
+    expect(result.args).toEqual([
+      codexSpawnConfig.promptFlag,
+      ...codexSpawnConfig.stdinMode!.extraArgs,
+      ...codexSpawnConfig.defaultArgs,
+      ...codexSpawnConfig.modes.yolo
+    ]);
+    expect(result.args).not.toContain(prompt);
+  });
+
   it("ignores useStdin for agents without stdinMode", () => {
     const result = buildSpawnArgs("opencode", { prompt: "hello", useStdin: true });
 

--- a/packages/agent-spawn/src/agent-spawn.test.ts
+++ b/packages/agent-spawn/src/agent-spawn.test.ts
@@ -477,17 +477,17 @@ describe("buildSpawnArgs", () => {
     expect(result.args).not.toContain(prompt);
   });
 
-  it("uses stdin args for codex when the prompt is too large for safe argv transport", () => {
+  it("does not silently switch buildSpawnArgs callers to stdin for large prompts", () => {
     const prompt = "x".repeat(128 * 1024);
     const result = buildSpawnArgs("codex", { prompt });
 
     expect(result.args).toEqual([
       codexSpawnConfig.promptFlag,
-      ...codexSpawnConfig.stdinMode!.extraArgs,
+      prompt,
       ...codexSpawnConfig.defaultArgs,
       ...codexSpawnConfig.modes.yolo
     ]);
-    expect(result.args).not.toContain(prompt);
+    expect(result.args).toContain(prompt);
   });
 
   it("ignores useStdin for agents without stdinMode", () => {

--- a/packages/agent-spawn/src/prompt-transport.ts
+++ b/packages/agent-spawn/src/prompt-transport.ts
@@ -1,8 +1,15 @@
 import type { CliSpawnConfig } from "./types.js";
 
+const MAX_SAFE_PROMPT_ARG_BYTES = 96 * 1024;
+
 export function shouldSendPromptViaStdin(
   config: CliSpawnConfig,
   options: { prompt: string; useStdin?: boolean }
 ): boolean {
-  return !!config.stdinMode && (options.useStdin === true || options.prompt.includes("\0"));
+  return (
+    !!config.stdinMode &&
+    (options.useStdin === true ||
+      options.prompt.includes("\0") ||
+      Buffer.byteLength(options.prompt, "utf8") > MAX_SAFE_PROMPT_ARG_BYTES)
+  );
 }

--- a/packages/agent-spawn/src/prompt-transport.ts
+++ b/packages/agent-spawn/src/prompt-transport.ts
@@ -1,15 +1,8 @@
 import type { CliSpawnConfig } from "./types.js";
 
-const MAX_SAFE_PROMPT_ARG_BYTES = 96 * 1024;
-
 export function shouldSendPromptViaStdin(
   config: CliSpawnConfig,
   options: { prompt: string; useStdin?: boolean }
 ): boolean {
-  return (
-    !!config.stdinMode &&
-    (options.useStdin === true ||
-      options.prompt.includes("\0") ||
-      Buffer.byteLength(options.prompt, "utf8") > MAX_SAFE_PROMPT_ARG_BYTES)
-  );
+  return !!config.stdinMode && (options.useStdin === true || options.prompt.includes("\0"));
 }


### PR DESCRIPTION
## Summary
- pipe code-review orchestrator and nested-reviewer prompts through stdin for plain-text-safe `codex` and `claude-code` agents, including documented aliases/case variants
- keep public `buildSpawnArgs()` behavior stable, so external callers do not silently lose oversized prompts
- avoid raw-text stdin for `kimi` and `goose`, whose stdin modes require different protocol/argument handling
- refresh the generated pipeline schema required by CI

## Motivation
While running the Yo todo dry-run against real review chores, code review exposed prompt-transport failures:

1. A large Codex review prompt failed with `E2BIG: argument list too long, posix_spawn 'codex'` when sent via argv.
2. Nested review-agent runs needed stdin-safe execution in the code-review workflow.

An initial broad fallback in `agent-spawn` was rejected during review because `buildSpawnArgs()` callers cannot provide stdin input and structured-input agents (`kimi` / `goose`) cannot accept raw review prompt text through their configured stdin modes. The final implementation confines stdin selection to code-review calls for compatible plain-text agents and resolves aliases through the existing spawn-config resolution path.

## Validation
- `npm exec -- vitest run packages/agent-spawn/src/agent-spawn.test.ts packages/agent-code-review/src/mcp.test.ts packages/agent-code-review/src/review.test.ts` (`96` passed)
- `npm run lint:eslint`
- `npm run lint:types`
- `npx prettier --check` on changed TypeScript files
- pre-push hook: full `npm run test` suite (`10903` passed, `1` skipped)