### PR TITLE
Publish tiny stdio testing export files

### DIFF
--- a/packages/tiny-stdio-mcp-server/package.json
+++ b/packages/tiny-stdio-mcp-server/package.json
@@ -24,8 +24,7 @@
     "prepublishOnly": "tsc"
   },
   "files": [
-    "dist",
-    "!dist/testing.*"
+    "dist"
   ],
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- remove the package files exclusion that prevented `dist/testing.js` and `dist/testing.d.ts` from being published
- keeps the documented `tiny-stdio-mcp-server/testing` subpath export resolvable in package tarballs

## Verification
- `npm run build --workspaces=false` from `packages/tiny-stdio-mcp-server`
- verified `dist/testing.js` and `dist/testing.d.ts` are generated
- `npm pack --dry-run --json` confirms both testing export targets are included
- `git diff --check`