### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/tiny-stdio-mcp-server/package.json
+++ b/packages/tiny-stdio-mcp-server/package.json
@@ -1,6 +1,9 @@
 {
   "name": "tiny-stdio-mcp-server",
   "version": "0.1.0",
+  "bugs": {
+    "url": "https://github.com/poe-platform/poe-code/issues"
+  },
   "description": "Minimal MCP server over stdio with typed tools and rich content helpers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/tiny-stdio-mcp-server/package.json`.

Fixes npm tooling unable to resolve package metadata.