### PR TITLE
fix(tests): support npm tar 6 and tar 7 archive parsers

### DIFF
--- a/packages/safe-bash/tests/integration/s3-http-exports/archive-controls.test.mjs
+++ b/packages/safe-bash/tests/integration/s3-http-exports/archive-controls.test.mjs
@@ -1018,6 +1018,7 @@ test("maintained outer launcher rejects inherited startup settings before the ve
     writeFileSync(join(directory, "exports.test.mjs"), launcher);
     assert.deepEqual(readFileSync(join(directory, "exports.test.mjs")), launcher);
     writeFileSync(join(directory, "archive-controls.test.mjs"), "export {};\n");
+    writeFileSync(join(directory, "archive-parser.test.mjs"), "export {};\n");
     writeFileSync(join(directory, "committed-archive.mjs"), `export { cleanEnvironment } from ${JSON.stringify(new URL("./committed-archive.mjs", import.meta.url).href)};\n`);
     const startupMarker = join(directory, "startup-ran");
     const verifierMarker = join(directory, "synthetic-verifier-ran");

--- a/packages/safe-bash/tests/integration/s3-http-exports/archive-parser.test.mjs
+++ b/packages/safe-bash/tests/integration/s3-http-exports/archive-parser.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { digest, readArchive, resolveTools } from "./committed-archive.mjs";
+
+// Exercise both public constructor names with the actual npm-bundled parser.
+// In-memory archive bytes keep these controls independent of package staging.
+for (const exportName of ["Parse", "Parser"]) {
+  test(`archive admission preserves safety with the ${exportName} tar API`, async () => {
+    const { tar } = resolveTools();
+    const Parser = tar.Parser ?? tar.Parse;
+    const parserApi = { [exportName]: Parser };
+    const archive = (path, type = "File") => {
+      const payload = Buffer.from("admitted bytes");
+      const header = new tar.Header({ path, type, size: type === "File" ? payload.length : 0, linkpath: type === "SymbolicLink" ? "allowed.txt" : "", mode: 0o644 });
+      const bytes = Buffer.alloc(2048);
+      header.encode(bytes);
+      if (type === "File") payload.copy(bytes, 512);
+      return bytes;
+    };
+    const read = (bytes, admit = () => {}, expectedHash = digest(bytes)) => readArchive(parserApi, "/control.tar", expectedHash, admit, {
+      lstatSync: () => ({ isFile: () => true, size: bytes.length }),
+      readFileSync: () => bytes,
+    });
+    const bytes = archive("allowed.txt");
+    const admitted = [];
+    const files = await read(bytes, path => admitted.push(path));
+    assert.deepEqual(admitted, ["allowed.txt"]);
+    assert.equal(files.get("allowed.txt").toString(), "admitted bytes");
+    await assert.rejects(read(bytes, () => assert.fail("must authenticate first"), "0".repeat(64)), /identity changed/);
+    await assert.rejects(read(bytes, () => assert.fail("unbound entry")), /unbound entry/);
+    await assert.rejects(read(archive("../escape")), /nonliteral input path/);
+    await assert.rejects(read(archive("link.txt", "SymbolicLink")), /nonregular archive entry/);
+    const duplicate = Buffer.concat([bytes.subarray(0, 1024), bytes]);
+    await assert.rejects(read(duplicate), /duplicate or excessive archive entries/);
+  });
+}

--- a/packages/safe-bash/tests/integration/s3-http-exports/committed-archive.mjs
+++ b/packages/safe-bash/tests/integration/s3-http-exports/committed-archive.mjs
@@ -551,7 +551,8 @@ export async function readArchive(tar, filename, expectedHash, admit, fileSystem
   const files = new Map();
   let expanded = 0;
   await new Promise((resolvePromise, reject) => {
-    const parser = new tar.Parser({ strict: true, maxMetaEntrySize: 1024 * 1024 });
+    const Parser = tar.Parser ?? tar.Parse;
+    const parser = new Parser({ strict: true, maxMetaEntrySize: 1024 * 1024 });
     parser.on("error", reject);
     parser.on("end", resolvePromise);
     parser.on("entry", entry => {

--- a/packages/safe-bash/tests/integration/s3-http-exports/exports.test.ts
+++ b/packages/safe-bash/tests/integration/s3-http-exports/exports.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 await import(new URL("./archive-controls.test.mjs", import.meta.url).href);
+await import(new URL("./archive-parser.test.mjs", import.meta.url).href);
 const { cleanEnvironment } = await import(new URL("./committed-archive.mjs", import.meta.url).href);
 
 test("S3 HTTP root/subpath exports work from a clean packed revision without source fallback", { timeout: 300_000 }, () => {


### PR DESCRIPTION
The committed-archive verifier currently fails before reading entries when the active npm installation bundles tar 6: that version exports `Parse`, while tar 7 exports `Parser`. Node 22.22.0 with npm 10.9.4 reproduces `TypeError: tar.Parser is not a constructor` across archive consumer checks.

Select `Parser` when available and otherwise use `Parse`. Keep the same strict parser options, byte authentication, path admission, entry restrictions, duplicate checks, and size limits.

Validation: the new in-memory regression fails for the Parse-only API before the change and passes for both constructor names afterward. It verifies admitted bytes and rejects mismatched hashes, unbound entries, traversal, symlinks, and duplicate entries. The existing archive admission control also passes. Guarded repository lint passed (10,528 files, zero errors/warnings, 25 boundary receipts). A separate exact-byte probe also passed with the actual installed tar 6.2.1 and tar 7.5.22 packages.

The wider archive-control suite passed 186 of 187 cases; its sole failure was a missing generated safe-fs declaration in the fresh checkout. After the maintained selected safe-fs build, that unchanged case passed. No fixture or policy was changed to resolve it.

This is a test-tool compatibility fix; it does not change shipped runtime code or relax archive policy. It is separate from the atomic resize feature in #711.

The follow-up wires both parser regressions into the maintained integration entrypoint. A discovery check found zero parser cases before that import; the same entrypoint now discovers and passes both cases (2/2). Guarded repository lint again passed with zero errors or warnings.

The isolated launcher fixture also registers the parser-test module so the clean and poisoned startup controls reach their synthetic verifier. The exact missing-module failure was reproduced before this fixture correction; the launcher and both real parser safety controls then passed together (3/3). Guarded lint passed again (10,528 files, zero errors/warnings, 25 receipts).

## Screenshots

Recorded local test-tool verification: actual npm tar 6.2.1 Parse and workspace tar 7.5.22 Parser both passed exact-byte probes. Not production or product UI evidence.

![Evidence 1](https://github.com/user-attachments/assets/2dd1e315-c758-4aa2-8391-e7b0a3577ef1)
