### PR TITLE
fix(safe-bash): explain typed curl output failures

### DIFF
--- a/packages/safe-bash/src/commands/network/output.ts
+++ b/packages/safe-bash/src/commands/network/output.ts
@@ -1,4 +1,4 @@
-import { readBytes, writeBytes, type ByteSource, type CommandContext } from "../../contracts/index.js";
+import { FsError, readBytes, writeBytes, type ByteSource, type CommandContext } from "../../contracts/index.js";
 import { openFileOutput } from "../../contracts/filesystem-output.js";
 import { outputFailure } from "../../contracts/io.js";
 import { pathOf } from "../internal.js";
@@ -42,7 +42,7 @@ export async function writeOutput(context: CommandContext, path: string | undefi
   } catch (error) {
     signal.throwIfAborted();
     if (error instanceof CurlError) throw error;
-    throw new CurlError(23, "Failed writing virtual output file");
+    throw new CurlError(23, error instanceof FsError ? `Failed writing virtual output file: ${error.message}` : "Failed writing virtual output file");
   }
 }
 

--- a/packages/safe-bash/tests/commands/network/mounted-output.test.ts
+++ b/packages/safe-bash/tests/commands/network/mounted-output.test.ts
@@ -93,7 +93,7 @@ for (const stage of ["before", "acquired", "consumed"] as const) {
   });
 }
 
-for (const failure of [new FsError("EACCES"), new FsError("EROFS"), new FsError("EIO"), { code: "ENOTSUP" }]) {
+for (const failure of [new FsError("EACCES"), new FsError("EROFS"), new FsError("EIO"), new FsError("EACCES", { path: "/out", message: "This loaded file is read-only. Write to a new path instead.", cause: new Error("private backend detail") }), { code: "ENOTSUP" }, Object.assign(new Error("private backend detail"), { code: "EACCES" })]) {
   test(`curl preserves stream failure without replay: ${failure.code}`, async () => {
     const backing = createMemoryFileSystem();
     const fs: FileSystem = { ...buffered(backing), capabilities: {} };
@@ -105,7 +105,10 @@ for (const failure of [new FsError("EACCES"), new FsError("EROFS"), new FsError(
     try {
       const result = await shell.exec("curl https://example.invalid/file -o /out");
       assert.equal(result.exitCode, 23);
-      assert.equal(result.stderr, "curl: (23) Failed writing virtual output file\n");
+      assert.equal(result.stderr, failure instanceof FsError
+        ? `curl: (23) Failed writing virtual output file: ${failure.message}\n`
+        : "curl: (23) Failed writing virtual output file\n");
+      assert.doesNotMatch(result.stderr, /private backend detail/u);
       assert.equal(writes, 0);
       assert.equal(produced, 0);
       await assert.rejects(backing.readFile("/out"), { code: "ENOENT" });
@@ -221,7 +224,7 @@ test("curl does not retry failed buffered appends after a partial mounted write"
   try {
     const result = await shell.exec("curl https://example.invalid/file -o /scratch/out");
     assert.equal(result.exitCode, 23);
-    assert.equal(result.stderr, "curl: (23) Failed writing virtual output file\n");
+    assert.equal(result.stderr, "curl: (23) Failed writing virtual output file: EIO: input/output error, appendFile '/scratch/out'\n");
     assert.equal(appended, 2);
     assert.equal(produced, 2);
     assert.deepEqual(await backing.readFile("/out"), new Uint8Array([1]));


### PR DESCRIPTION
When curl cannot write a downloaded file, it currently replaces the filesystem's typed refusal with a generic error 23. An agent trying to overwrite a loaded read-only file cannot see why the download failed.

Preserve the message of a typed `FsError` in curl's output diagnostic. Keep error 23 and preserve the generic message for arbitrary exceptions. Nested error causes are not exposed.

The network regression verifies the typed read-only reason, generic handling of an untyped exception even when it carries a filesystem-like code, and the absence of a private nested cause. Existing partial-write failure expectations now include the typed filesystem reason.

Validation: 59 focused network tests pass. Owning source/test typecheck and all 26 public consumer groups pass. The maintained root build and guarded ESLint pass (10,527 files, zero diagnostics, 25 boundary receipts). A separate Poe2 consumer change supplies actionable new-path guidance while retaining loaded-file immutability.

## Screenshots

Recorded downstream controlled Poe2 integration with the consumer guidance change: actual execute_shell/API/native storage results and deterministic image responses rendered in Chat. Immutable overwrite retains exit 23; writing a new path succeeds and original bytes were verified unchanged. No model run or production service; not standalone upstream proof.

![Evidence 1](https://github.com/user-attachments/assets/df36e0c4-2911-4c6d-a48c-ce939d393481)
