### PR TITLE
fix(ci): configure runtime models and MCP test fixtures

### DIFF
--- a/.github/workflows/gh-github-pull-request-opened.yml
+++ b/.github/workflows/gh-github-pull-request-opened.yml
@@ -120,7 +120,7 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-opened --yes
+      - run: poe-code github-workflows github-pull-request-opened --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
@@ -129,3 +129,4 @@ jobs:
           PR_TITLE: ${{ inputs.PR_TITLE }}
           PR_AUTHOR: ${{ inputs.PR_AUTHOR }}
           GITHUB_REPOSITORY: ${{ inputs.GITHUB_REPOSITORY }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/.github/workflows/gh-github-pull-request-synchronized.yml
+++ b/.github/workflows/gh-github-pull-request-synchronized.yml
@@ -114,10 +114,11 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-synchronized --yes
+      - run: poe-code github-workflows github-pull-request-synchronized --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
           GITHUB_REPOSITORY: ${{ inputs.GITHUB_REPOSITORY }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/.github/workflows/poe-code-github-pull-request-opened.yml
+++ b/.github/workflows/poe-code-github-pull-request-opened.yml
@@ -2,7 +2,7 @@
 name: 'GitHub: Pull Request Opened'
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ opened, ready_for_review ]
 
 jobs:
   guard:
@@ -103,7 +103,7 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-opened --yes
+      - run: poe-code github-workflows github-pull-request-opened --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
@@ -112,3 +112,4 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/.github/workflows/poe-code-github-pull-request-synchronized.yml
+++ b/.github/workflows/poe-code-github-pull-request-synchronized.yml
@@ -2,7 +2,7 @@
 name: 'GitHub: Pull Request Synchronized'
 on:
   pull_request:
-    types: [synchronize]
+    types: [ synchronize ]
 
 jobs:
   guard:
@@ -103,10 +103,11 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-synchronized --yes
+      - run: poe-code github-workflows github-pull-request-synchronized --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/e2e/claude-code.test.ts
+++ b/e2e/claude-code.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useContainer } from '@poe-code/e2e-test-runner';
+import { useContainer, shellQuote } from '@poe-code/e2e-test-runner';
+import { resolveE2eModel } from './runtime-models.js';
 
 describe('claude-code', () => {
   const container = useContainer({ testName: 'claude-code' });
@@ -19,12 +20,12 @@ describe('claude-code', () => {
     expect(config).not.toHaveProperty('env.ANTHROPIC_CUSTOM_HEADERS');
     expect(config).toHaveProperty('env.ANTHROPIC_BASE_URL');
 
-    const testResult = await container.exec('poe-code test claude-code');
+    const testResult = await container.exec(`poe-code test claude-code --model ${shellQuote(resolveE2eModel('claude-code'))}`);
     expect(testResult).toSucceedWith('Tested Claude Code.');
   });
 
   it('test --isolated', async () => {
-    const result = await container.exec('poe-code test claude-code --isolated');
+    const result = await container.exec(`poe-code test claude-code --isolated --model ${shellQuote(resolveE2eModel('claude-code'))}`);
     expect(result).toSucceedWith('Tested Claude Code.');
   });
 });

--- a/e2e/mcp-fixture.ts
+++ b/e2e/mcp-fixture.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url';
+import type { Backend } from '@poe-code/e2e-test-runner';
+
+export function resolveMcpFixtureCommand(backend: Backend): { command: string; args: string[] } {
+  if (backend === 'podman') {
+    return { command: 'tiny-stdio-mcp-test-server', args: ['serve', 'word-of-the-day'] };
+  }
+  // npm ci runs before build, so the workspace bin link may not exist.
+  // Host backends can invoke the built fixture without a link or executable bit.
+  return {
+    command: process.execPath,
+    args: [fileURLToPath(new URL('../packages/tiny-stdio-mcp-test-server/dist/cli.js', import.meta.url)), 'serve', 'word-of-the-day'],
+  };
+}

--- a/e2e/mcp-tool.test.ts
+++ b/e2e/mcp-tool.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useContainer, shellQuote } from '@poe-code/e2e-test-runner';
+import { resolveE2eModel, registerKimiFixtureModel } from './runtime-models.js';
 
 interface AgentMcpSpawnTest {
-  name: string;
+  name: Parameters<typeof resolveE2eModel>[0];
   expectSpawnSuccess: boolean;
   spawnArgs?: string[];
 }
@@ -51,11 +52,18 @@ describe.each(agents)('spawn --mcp-config: $name', ({ name, expectSpawnSuccess, 
     const configResult = await container.exec(`poe-code configure ${name} --yes`);
     expect(configResult).toHaveExitCode(0);
 
+    const model = resolveE2eModel(name);
+    if (name === 'kimi') {
+      const configPath = `${container.home}/.kimi/config.toml`;
+      const contextSize = Number(process.env.POE_CODE_E2E_KIMI_CONTEXT_SIZE ?? 131072);
+      await container.writeFile(configPath, registerKimiFixtureModel(await container.readFile(configPath), model, contextSize));
+    }
+
     const prompt = 'Call the word_of_the_day tool and return only the exact tool output.';
     const extraArgs = spawnArgs
       ? ` -- ${spawnArgs.map((arg) => shellQuote(arg)).join(' ')}`
       : '';
-    const command = `poe-code spawn --mode yolo --mcp-config ${mcpConfig} ${name} ${shellQuote(prompt)}${extraArgs}`;
+    const command = `poe-code spawn --mode yolo --model ${shellQuote(model)} --mcp-config ${mcpConfig} ${name} ${shellQuote(prompt)}${extraArgs}`;
     const spawnResult = await container.exec(command);
 
     if (!expectSpawnSuccess) {

--- a/e2e/mcp-tool.test.ts
+++ b/e2e/mcp-tool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useContainer, shellQuote } from '@poe-code/e2e-test-runner';
+import { useContainer, shellQuote, resolveBackend } from '@poe-code/e2e-test-runner';
+import { resolveMcpFixtureCommand } from './mcp-fixture.js';
 import { resolveE2eModel, registerKimiFixtureModel } from './runtime-models.js';
 
 interface AgentMcpSpawnTest {
@@ -34,10 +35,7 @@ const agents: AgentMcpSpawnTest[] = [
 ];
 
 const mcpConfig = shellQuote(JSON.stringify({
-  'tiny-stdio-mcp-test-server': {
-    command: 'tiny-stdio-mcp-test-server',
-    args: ['serve', 'word-of-the-day'],
-  },
+  'tiny-stdio-mcp-test-server': resolveMcpFixtureCommand(resolveBackend()),
 }));
 
 describe.each(agents)('spawn --mcp-config: $name', ({ name, expectSpawnSuccess, spawnArgs }) => {

--- a/e2e/mcp-tool.test.ts
+++ b/e2e/mcp-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useContainer, shellQuote, resolveBackend } from '@poe-code/e2e-test-runner';
 import { resolveMcpFixtureCommand } from './mcp-fixture.js';
-import { resolveE2eModel, registerKimiFixtureModel } from './runtime-models.js';
+import { resolveE2eModel, resolveE2eModelEnvironment, registerKimiFixtureModel } from './runtime-models.js';
 
 interface AgentMcpSpawnTest {
   name: Parameters<typeof resolveE2eModel>[0];
@@ -61,7 +61,9 @@ describe.each(agents)('spawn --mcp-config: $name', ({ name, expectSpawnSuccess, 
     const extraArgs = spawnArgs
       ? ` -- ${spawnArgs.map((arg) => shellQuote(arg)).join(' ')}`
       : '';
-    const command = `poe-code spawn --mode yolo --model ${shellQuote(model)} --mcp-config ${mcpConfig} ${name} ${shellQuote(prompt)}${extraArgs}`;
+    const modelEnv = Object.entries(resolveE2eModelEnvironment(name, model))
+      .map(([key, value]) => `${key}=${shellQuote(value)}`);
+    const command = [...modelEnv, `poe-code spawn --mode yolo --model ${shellQuote(model)} --mcp-config ${mcpConfig} ${name} ${shellQuote(prompt)}${extraArgs}`].join(' ');
     const spawnResult = await container.exec(command);
 
     if (!expectSpawnSuccess) {

--- a/e2e/runtime-models.ts
+++ b/e2e/runtime-models.ts
@@ -1,0 +1,28 @@
+import { parse, stringify, type TomlTable } from "smol-toml";
+
+const models = {
+  "claude-code": { env: "POE_CODE_E2E_CLAUDE_CODE_MODEL", model: "claude-sonnet-4.6" },
+  codex: { env: "POE_CODE_E2E_CODEX_MODEL", model: "gpt-5.4" },
+  opencode: { env: "POE_CODE_E2E_OPENCODE_MODEL", model: "gpt-5.4" },
+  kimi: { env: "POE_CODE_E2E_KIMI_MODEL", model: "gpt-5.4" },
+  goose: { env: "POE_CODE_E2E_GOOSE_MODEL", model: "gpt-5.4" },
+} as const;
+
+export function resolveE2eModel(agent: keyof typeof models, env: NodeJS.ProcessEnv = process.env): string {
+  const selected = models[agent];
+  return env[selected.env]?.trim() || selected.model;
+}
+
+export function registerKimiFixtureModel(source: string, model: string, maxContextSize = 131072): string {
+  const config = parse(source);
+  const providers = config.providers as TomlTable | undefined;
+  if (!providers?.poe) throw new Error("Configure the poe provider before registering the Kimi fixture model");
+  const configured = (config.models ?? {}) as TomlTable;
+  if (Object.hasOwn(configured, model)) return source;
+  if (!Number.isSafeInteger(maxContextSize) || maxContextSize <= 0) throw new Error("Kimi fixture context size must be a positive integer");
+  return stringify({ ...config, models: { ...configured,
+    // Keep this fixture below the selected GPT-5.4 context limit; native user
+    // aliases above retain their own context configuration unchanged.
+    [model]: { provider: "poe", model, max_context_size: maxContextSize },
+  } });
+}

--- a/e2e/runtime-models.ts
+++ b/e2e/runtime-models.ts
@@ -26,3 +26,9 @@ export function registerKimiFixtureModel(source: string, model: string, maxConte
     [model]: { provider: "poe", model, max_context_size: maxContextSize },
   } });
 }
+
+export function resolveE2eModelEnvironment(agent: keyof typeof models, model: string): Record<string, string> {
+  // Goose v1.50.0 ACP reads the model from config/environment before session/new;
+  // its ACP command has no --model flag. Keep this scoped to the live fixture.
+  return agent === "goose" ? { GOOSE_MODEL: model } : {};
+}

--- a/e2e/tiny-mcp-server.test.ts
+++ b/e2e/tiny-mcp-server.test.ts
@@ -42,8 +42,8 @@ describe("tiny MCP server", () => {
   });
 
   it("serves prompts and resources over a real HTTP listener", async () => {
-    const server = createHttpServer({ name: "e2e-http", version: "1.0.0" })
-      .prompt({ name: "hello" }, () => ({ messages: [{ role: "user", content: { type: "text", text: "hello" } }] }))
+    const server = createHttpServer({ name: "e2e-http", version: "1.0.0" });
+    server.prompt({ name: "hello" }, () => ({ messages: [{ role: "user", content: { type: "text", text: "hello" } }] }))
       .resource({ uri: "memory://hello", name: "hello" }, () => ({ contents: [{ uri: "memory://hello", text: "hello" }] }));
     const handle = await server.listenHttp({ port: 0 });
     const client = new Client({ name: "e2e-http-client", version: "1.0.0" });

--- a/packages/agent-spawn/src/agent-spawn.test.ts
+++ b/packages/agent-spawn/src/agent-spawn.test.ts
@@ -201,6 +201,13 @@ describe("stripModelNamespace", () => {
 // === build-spawn-args.test.ts ===
 
 describe("buildSpawnArgs", () => {
+  it("forwards an explicit Kimi model alias without choosing a default", () => {
+    const selected = buildSpawnArgs("kimi", { prompt: "test", model: "custom/model-alias", mode: "yolo" });
+    expect(selected.args).toContain("--model");
+    expect(selected.args[selected.args.indexOf("--model") + 1]).toBe("custom/model-alias");
+    expect(buildSpawnArgs("kimi", { prompt: "test", mode: "yolo" }).args).not.toContain("--model");
+  });
+
   it("throws error if agent ID cannot be resolved", () => {
     expect(() => buildSpawnArgs("unknown", { prompt: "test" })).toThrow(/Unknown agent/);
   });

--- a/packages/agent-spawn/src/configs/kimi.ts
+++ b/packages/agent-spawn/src/configs/kimi.ts
@@ -9,7 +9,9 @@ export const kimiSpawnConfig: CliSpawnConfig = {
   // (no `{ event, ... }` field), so it needs the Kimi adapter (not "native").
   adapter: "kimi",
   promptFlag: "-p",
-  modelStripProviderPrefix: true,
+  modelFlag: "--model",
+  // Kimi selects a local models-table alias, which may itself contain slashes.
+  modelStripProviderPrefix: false,
   defaultArgs: ["--print", "--output-format", "stream-json"],
   mcpArgs: serializeJsonMcpArgs,
   modes: {

--- a/packages/github-workflows/src/workflow-templates/github-pull-request-opened.ejected.yml
+++ b/packages/github-workflows/src/workflow-templates/github-pull-request-opened.ejected.yml
@@ -1,7 +1,7 @@
 name: 'GitHub: Pull Request Opened'
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ opened, ready_for_review ]
 
 jobs:
   guard:
@@ -104,7 +104,7 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-opened --yes
+      - run: poe-code github-workflows github-pull-request-opened --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
@@ -113,3 +113,4 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/packages/github-workflows/src/workflow-templates/github-pull-request-synchronized.ejected.yml
+++ b/packages/github-workflows/src/workflow-templates/github-pull-request-synchronized.ejected.yml
@@ -1,7 +1,7 @@
 name: 'GitHub: Pull Request Synchronized'
 on:
   pull_request:
-    types: [synchronize]
+    types: [ synchronize ]
 
 jobs:
   guard:
@@ -104,10 +104,11 @@ jobs:
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
-      - run: poe-code github-workflows github-pull-request-synchronized --yes
+      - run: poe-code github-workflows github-pull-request-synchronized --yes --model "${POE_CODE_REVIEW_MODEL:-gpt-5.4}"
         env:
           POE_CODE_STDERR_LOGS: "1"
           POE_API_KEY: ${{ secrets.POE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          POE_CODE_REVIEW_MODEL: ${{ vars.POE_CODE_REVIEW_MODEL }}

--- a/packages/safe-bash-playground/src/engine/kernel.test.ts
+++ b/packages/safe-bash-playground/src/engine/kernel.test.ts
@@ -13,6 +13,7 @@ describe("real safe-bash browser kernel", () => {
   const activeWorkers = new Set<{ terminate(): void }>();
 
   beforeAll(async () => {
+    vi.stubGlobal("navigator", { language: "en-US" });
     vi.stubGlobal(
       "Worker",
       class extends EventTarget {
@@ -28,6 +29,7 @@ describe("real safe-bash browser kernel", () => {
             const worker = new NodeWorker(
               `
             const { parentPort } = require('node:worker_threads');
+            Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { language: 'en-US' } });
             globalThis.addEventListener = (event, handler) => parentPort.on(event, data => handler({ data }));
             globalThis.postMessage = (value, transfer) => parentPort.postMessage(value, transfer);
             ${code}

--- a/packages/safe-bash-playground/src/execution-filesystem.test.ts
+++ b/packages/safe-bash-playground/src/execution-filesystem.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { createMemoryFileSystem, FsError } from "./engine/index.js";
 import type { FileSystem } from "./engine/index.js";
 import { decodeError, encodeError, hostFileSystem, remoteFileSystem } from "./execution-filesystem.js";
+
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+afterAll(() => vi.unstubAllGlobals());
 
 vi.mock("./engine/index.js", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");

--- a/packages/safe-bash-playground/src/execution.test.ts
+++ b/packages/safe-bash-playground/src/execution.test.ts
@@ -7,6 +7,8 @@ import type { ExecutionMessage } from "./execution-protocol.js";
 import { browserWorkerFixture } from "../test/browser-worker.js";
 import { setTimeout as delay } from "node:timers/promises";
 
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+
 vi.mock("virtual:safe-bash-worker-sources", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");
   return { sources: (await buildBrowserEngine({ workersOnly: true })).workerSources };

--- a/packages/safe-bash-playground/src/session.test.ts
+++ b/packages/safe-bash-playground/src/session.test.ts
@@ -3,6 +3,8 @@ import { createSession, SESSION_LIMITS } from "./session.js";
 import { sampleFiles } from "./samples.js";
 import { browserWorkerFixture } from "../test/browser-worker.js";
 
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+
 vi.mock("virtual:safe-bash-worker-sources", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");
   return { sources: (await buildBrowserEngine({ workersOnly: true })).workerSources };

--- a/packages/safe-bash-playground/test/browser-worker.ts
+++ b/packages/safe-bash-playground/test/browser-worker.ts
@@ -18,6 +18,7 @@ export function browserWorkerFixture(executionSource: string) {
       this.worker = source.then((code) => {
         const worker = new NodeWorker(`
           const { parentPort } = require("node:worker_threads");
+          Object.defineProperty(globalThis, "navigator", { configurable: true, value: { language: "en-US" } });
           globalThis.addEventListener = (event, handler) => parentPort.on(event, data => handler({ data }));
           globalThis.postMessage = value => parentPort.postMessage(value);
           (() => { ${code} })();

--- a/packages/safe-js/src/interp/intrinsic-retained-roots-cache.test.ts
+++ b/packages/safe-js/src/interp/intrinsic-retained-roots-cache.test.ts
@@ -1,0 +1,119 @@
+import { expect, it, vi } from "vitest";
+import { Budget, SandboxError } from "./budget.js";
+import { accessorAdapter } from "./accessors.js";
+import { completeIntrinsicObjectInitialization, createIntrinsicObject, materializeFunctionProperties, registerIntrinsicFunction, registerIntrinsicObject, releaseObjectPrototype, setSandboxPrototype } from "./object-model.js";
+import { createSandboxClosure, measureSandboxData, reconcileCompiledValues, type SandboxObject } from "./values.js";
+
+it("reuses the collected roots while still rejecting nested growth above the memory limit", () => {
+  const budget = new Budget({ dataSize: 100 });
+  const registration = vi.spyOn(budget, "setRetainedValues");
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  const collect = registration.mock.calls.at(-1)![1]!;
+  const nested = { payload: "small" };
+  root.extra = nested;
+  try {
+    const roots = collect();
+    expect([...roots]).toEqual(["extra", nested]);
+    expect(collect()).toBe(roots);
+    reconcileCompiledValues(budget, []);
+    nested.payload = "x".repeat(200);
+    expect(collect()).toBe(roots);
+    expect(() => reconcileCompiledValues(budget, [])).toThrow(SandboxError);
+  } finally { registration.mockRestore(); releaseObjectPrototype(budget); }
+});
+
+it("refreshes collected roots after define, delete, accessors, prototype changes and baseline completion", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  const read = vi.fn(() => undefined);
+  const getter = createSandboxClosure({ guest: true, call: read, retainedValues: () => ["captured"] });
+  const parent = { payload: "parent" };
+  try {
+    expect([...budget.retainedValues()]).toEqual([]);
+    Object.defineProperty(root, "extra", { value: "defined", configurable: true });
+    expect([...budget.retainedValues()]).toEqual(["extra", "defined"]);
+    delete root.extra;
+    expect([...budget.retainedValues()]).toEqual([]);
+    Object.defineProperty(root, "extra", { get: accessorAdapter(getter, "get"), configurable: true });
+    expect([...budget.retainedValues()]).toEqual(["extra", undefined, getter]);
+    setSandboxPrototype(root, parent, budget);
+    expect([...budget.retainedValues()]).toEqual([parent, "extra", undefined, getter]);
+    completeIntrinsicObjectInitialization(budget, root);
+    expect([...budget.retainedValues()]).toEqual([]);
+    delete root.extra;
+    setSandboxPrototype(root, null, budget);
+    expect([...budget.retainedValues()]).toEqual([null]);
+    expect(read).not.toHaveBeenCalled();
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("remeasures mutations through an untracked restored property-table alias", () => {
+  const budget = new Budget();
+  const method = createSandboxClosure({ guest: true, name: "restored", call: () => undefined });
+  const restored: SandboxObject = { name: "restored" };
+  expect(materializeFunctionProperties(method, restored)).toBe(restored);
+  registerIntrinsicFunction(budget, method);
+  try {
+    expect([...budget.retainedValues()]).toEqual([]);
+    restored.extra = "first";
+    expect([...budget.retainedValues()]).toEqual(["extra", "first"]);
+    restored.extra = "longer";
+    expect(measureSandboxData(budget.retainedValues())).toBe(11);
+    delete restored.extra;
+    expect([...budget.retainedValues()]).toEqual([]);
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("keeps committed roots after failed definitions and deletions", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  try {
+    Object.defineProperty(root, "locked", { value: "retained", configurable: false, writable: false });
+    expect([...budget.retainedValues()]).toEqual(["locked", "retained"]);
+    expect(Reflect.defineProperty(root, "locked", { value: "replacement" })).toBe(false);
+    expect(Reflect.deleteProperty(root, "locked")).toBe(false);
+    Object.preventExtensions(root);
+    expect(Reflect.defineProperty(root, "new", { value: "uncommitted" })).toBe(false);
+    expect([...budget.retainedValues()]).toEqual(["locked", "retained"]);
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("keeps both budgets current and ignores rejected prototype mutations", () => {
+  const first = new Budget();
+  const second = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(first, root);
+  registerIntrinsicObject(second, root);
+  const parent = { retained: "parent" };
+  try {
+    expect([...first.retainedValues()]).toEqual([]);
+    expect([...second.retainedValues()]).toEqual([]);
+    setSandboxPrototype(root, parent);
+    expect([...first.retainedValues()]).toEqual([parent]);
+    expect([...second.retainedValues()]).toEqual([parent]);
+    expect(setSandboxPrototype(parent, root, undefined, false)).toBe(false);
+    Object.preventExtensions(root);
+    expect(setSandboxPrototype(root, {}, undefined, false)).toBe(false);
+    expect([...first.retainedValues()]).toEqual([parent]);
+    releaseObjectPrototype(first);
+    expect([...second.retainedValues()]).toEqual([parent]);
+  } finally { releaseObjectPrototype(first); releaseObjectPrototype(second); }
+});
+
+it("keeps root snapshots stable when a retained callback mutates the next collection", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  root.first = createSandboxClosure({ call: () => undefined, retainedValues: () => {
+    root.later = "z".repeat(100);
+    return [];
+  } });
+  root.later = "initial";
+  try {
+    expect(measureSandboxData(budget.retainedValues())).toBe(18);
+    expect(measureSandboxData(budget.retainedValues())).toBe(111);
+  } finally { releaseObjectPrototype(budget); }
+});

--- a/packages/safe-js/src/interp/object-model.ts
+++ b/packages/safe-js/src/interp/object-model.ts
@@ -42,11 +42,17 @@ const functionPropertyRevisions = new WeakMap<object, {
 const trackedIntrinsicObjects = new WeakSet<object>();
 const prototypes = new WeakMap<object, object | null>();
 const trackedPrototypes = new WeakMap<object, { current: object | null }>();
+// Identity tokens cannot overflow. Unrelated mutations conservatively invalidate
+// all groups without retaining subscriber lists or their owning budgets.
+let intrinsicMutationToken = {};
 
 function storePrototype(value: object, prototype: object | null): void {
   prototypes.set(value, prototype);
   const tracked = trackedPrototypes.get(value);
-  if (tracked !== undefined) tracked.current = prototype;
+  if (tracked !== undefined && tracked.current !== prototype) {
+    tracked.current = prototype;
+    intrinsicMutationToken = {};
+  }
 }
 const intrinsicPrototypes = new WeakMap<Budget, SandboxObject>();
 const boxedPrototypes = new WeakMap<Budget, Map<BoxedKind, SandboxObject>>();
@@ -140,12 +146,18 @@ function trackPropertyTable(properties: SandboxObject): SandboxObject {
   const tracked = new Proxy(properties, {
     defineProperty(target, key, descriptor) {
       const changed = Reflect.defineProperty(target, key, descriptor);
-      if (changed) state.revision++;
+      if (changed) {
+        state.revision++;
+        intrinsicMutationToken = {};
+      }
       return changed;
     },
     deleteProperty(target, key) {
       const changed = Reflect.deleteProperty(target, key);
-      if (changed) state.revision++;
+      if (changed) {
+        state.revision++;
+        intrinsicMutationToken = {};
+      }
       return changed;
     }
   });
@@ -293,6 +305,7 @@ export function completeIntrinsicObjectInitialization(budget: Budget, value: San
     const record = records.find(record => record.target === value);
     if (record === undefined) continue;
     Object.assign(record, captureIntrinsicRecords([value])[0]);
+    intrinsicMutationToken = {};
     return;
   }
 }
@@ -371,7 +384,14 @@ function trackIntrinsicState(
     retainedRecords.push(record);
   }
   if (retainedRecords.length === 0) return;
+  const cacheable = retainedRecords.every(record => record.revision !== undefined);
+  let capturedToken: object | undefined;
+  let capturedRoots: unknown[] = [];
   budget.setRetainedValues(root, () => {
+    // O(1) root collection when tracked tables are unchanged. Only references
+    // are reused: measurement still recursively visits their current contents.
+    // Restored/untracked tables must always take the conservative scan below.
+    if (cacheable && capturedToken === intrinsicMutationToken) return capturedRoots;
     // Capture every change before measurement invokes retained-value callbacks.
     const retained: unknown[] = [];
     for (const record of retainedRecords) {
@@ -389,6 +409,10 @@ function trackIntrinsicState(
         record.capturedRevision = revision?.revision ?? -1;
       }
       for (const item of record.captured) retained.push(item);
+    }
+    if (cacheable) {
+      capturedRoots = retained;
+      capturedToken = intrinsicMutationToken;
     }
     return retained;
   });

--- a/packages/toolcraft/src/stream.test.ts
+++ b/packages/toolcraft/src/stream.test.ts
@@ -7,6 +7,12 @@ import {
   type ToolcraftStream
 } from "./index.js";
 
+async function collect<Value>(stream: AsyncIterable<Value>): Promise<Value[]> {
+  const values: Value[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
 describe("defineStreamCommand SDK lifecycle", () => {
   it("starts lazily and advances only when the consumer pulls", async () => {
     const produced: number[] = [];
@@ -78,7 +84,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
 
     const stream = sdk.watch({}, { onStatus: (event) => statuses.push(event) });
 
-    await expect(Array.fromAsync(stream)).resolves.toEqual([{ state: "fresh-token" }]);
+    await expect(collect(stream)).resolves.toEqual([{ state: "fresh-token" }]);
     expect(statuses).toEqual([
       { type: "reconnecting", message: "Refreshing credentials" }
     ]);
@@ -95,7 +101,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
     });
     const sdk = createSDK(defineGroup({ name: "devices", children: [watch] }));
 
-    await expect(Array.fromAsync(sdk.watch({}))).rejects.toThrow("state");
+    await expect(collect(sdk.watch({}))).rejects.toThrow("state");
   });
 
   it("propagates terminal errors and releases resources once", async () => {
@@ -115,7 +121,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
     });
     const sdk = createSDK(defineGroup({ name: "devices", children: [watch] }));
 
-    await expect(Array.fromAsync(sdk.watch({}))).rejects.toThrow("connection lost");
+    await expect(collect(sdk.watch({}))).rejects.toThrow("connection lost");
     expect(cleanup).toHaveBeenCalledOnce();
   });
 });

--- a/scripts/e2e-mcp-fixture.test.ts
+++ b/scripts/e2e-mcp-fixture.test.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { describe, expect, it } from 'vitest';
+import { resolveMcpFixtureCommand } from '../e2e/mcp-fixture.js';
+
+describe('MCP agent fixture command', () => {
+  it.each(['env', 'sandbox'] as const)('uses the built CLI directly on the %s host', (backend) => {
+    expect(resolveMcpFixtureCommand(backend)).toEqual({
+      command: process.execPath,
+      args: [fileURLToPath(new URL('../packages/tiny-stdio-mcp-test-server/dist/cli.js', import.meta.url)), 'serve', 'word-of-the-day'],
+    });
+  });
+
+  it('preserves the installed executable inside Podman', () => {
+    expect(resolveMcpFixtureCommand('podman')).toEqual({
+      command: 'tiny-stdio-mcp-test-server', args: ['serve', 'word-of-the-day'],
+    });
+  });
+
+  it('connects and calls the real built fixture without workspace bin links', async () => {
+    const client = new Client({ name: 'offline-fixture-regression', version: '1.0.0' });
+    try {
+      await client.connect(new StdioClientTransport({ ...resolveMcpFixtureCommand('env'), stderr: 'pipe' }));
+      expect((await client.listTools()).tools.map((tool) => tool.name)).toContain('word_of_the_day');
+      expect(await client.callTool({ name: 'word_of_the_day', arguments: {} })).toMatchObject({
+        content: [{ type: 'text', text: 'Bumfuzzle - to confuse or fluster someone' }],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/scripts/e2e-runtime-models.test.ts
+++ b/scripts/e2e-runtime-models.test.ts
@@ -1,6 +1,7 @@
+import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { parse, stringify } from "smol-toml";
-import { resolveE2eModel, registerKimiFixtureModel } from "../e2e/runtime-models.js";
+import { resolveE2eModel, resolveE2eModelEnvironment, registerKimiFixtureModel } from "../e2e/runtime-models.js";
 
 describe("live-test runtime models", () => {
   it("selects endpoint-compatible fixtures and preserves explicit overrides", () => {
@@ -33,5 +34,23 @@ describe("live-test runtime models", () => {
       another: { provider: "poe", model: "another", max_context_size: 64000 },
     });
     expect(() => registerKimiFixtureModel(config, "another", Number.NaN)).toThrow("positive integer");
+  });
+});
+
+
+describe("native model environment for E2E", () => {
+  it("forwards the selected Goose model and preserves its fixture override", () => {
+    for (const override of [undefined, "custom/model; literal"]) {
+      const model = resolveE2eModel("goose", { POE_CODE_E2E_GOOSE_MODEL: override });
+      const env = resolveE2eModelEnvironment("goose", model);
+      expect(env).toEqual({ GOOSE_MODEL: override ?? "gpt-5.4" });
+      expect(execFileSync(process.execPath, ["-e", "process.stdout.write(process.env.GOOSE_MODEL ?? '')"], {
+        encoding: "utf8", env: { ...process.env, ...env },
+      })).toBe(model);
+    }
+  });
+
+  it.each(["claude-code", "codex", "opencode", "kimi"] as const)("leaves %s runtime environment unchanged", (agent) => {
+    expect(resolveE2eModelEnvironment(agent, "selected")).toEqual({});
   });
 });

--- a/scripts/e2e-runtime-models.test.ts
+++ b/scripts/e2e-runtime-models.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parse, stringify } from "smol-toml";
+import { resolveE2eModel, registerKimiFixtureModel } from "../e2e/runtime-models.js";
+
+describe("live-test runtime models", () => {
+  it("selects endpoint-compatible fixtures and preserves explicit overrides", () => {
+    expect(resolveE2eModel("claude-code", {})).toBe("claude-sonnet-4.6");
+    expect(resolveE2eModel("codex", {})).toBe("gpt-5.4");
+    expect(resolveE2eModel("kimi", { POE_CODE_E2E_KIMI_MODEL: "custom-alias" })).toBe("custom-alias");
+  });
+
+  it("registers the selected Kimi model without replacing provider credentials or preferences", () => {
+    const original = {
+      default_model: "personal", default_thinking: true,
+      providers: { poe: { type: "openai_legacy", base_url: "https://api.poe.com/v1", api_key: "fixture-key" } },
+      models: { personal: { provider: "poe", model: "other", max_context_size: 64000 } },
+    };
+    const result = parse(registerKimiFixtureModel(stringify(original), "gpt-5.4"));
+    expect(result).toEqual({ ...original, models: { ...original.models,
+      "gpt-5.4": { provider: "poe", model: "gpt-5.4", max_context_size: 131072 },
+    } });
+  });
+
+  it("preserves a user-defined model alias and refuses a missing provider", () => {
+    const config = stringify({ providers: { poe: {} }, models: { custom: { provider: "other", model: "selected", max_context_size: 12345 } } });
+    expect(registerKimiFixtureModel(config, "custom")).toBe(config);
+    expect(() => registerKimiFixtureModel("", "gpt-5.4")).toThrow("poe provider");
+  });
+
+  it("uses an explicit context bound for another fixture model and rejects invalid bounds", () => {
+    const config = stringify({ providers: { poe: {} } });
+    expect(parse(registerKimiFixtureModel(config, "another", 64000)).models).toEqual({
+      another: { provider: "poe", model: "another", max_context_size: 64000 },
+    });
+    expect(() => registerKimiFixtureModel(config, "another", Number.NaN)).toThrow("positive integer");
+  });
+});

--- a/scripts/reviewer-runtime-model.test.ts
+++ b/scripts/reviewer-runtime-model.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+describe("reviewer runtime invocation", () => {
+  for (const event of ["opened", "synchronized"]) {
+    for (const path of [
+      `packages/github-workflows/src/workflow-templates/github-pull-request-${event}.ejected.yml`,
+      `.github/workflows/gh-github-pull-request-${event}.yml`,
+      `.github/workflows/poe-code-github-pull-request-${event}.yml`,
+    ]) {
+    it(`passes a supported default and an unchanged override in ${path}`, () => {
+      const workflow = parse(readFileSync(path, "utf8"));
+      const step = workflow.jobs.run.steps.find((entry: { run?: string }) => entry.run?.includes(`github-workflows github-pull-request-${event} --yes`));
+      expect(step.env.POE_CODE_REVIEW_MODEL).toBe("${{ vars.POE_CODE_REVIEW_MODEL }}");
+      const run = (model: string) => execFileSync("bash", ["-c", `poe-code() { printf '%s\\n' "$@"; }; ${step.run}`], {
+        encoding: "utf8", env: { PATH: process.env.PATH, POE_CODE_REVIEW_MODEL: model },
+      }).trim().split("\n");
+      expect(run("").slice(-2)).toEqual(["--model", "gpt-5.4"]);
+      expect(run("chosen-model").slice(-2)).toEqual(["--model", "chosen-model"]);
+      expect(run("chosen model; literal").slice(-2)).toEqual(["--model", "chosen model; literal"]);
+    });
+    }
+  }
+});

--- a/src/cli/commands/commands.test.ts
+++ b/src/cli/commands/commands.test.ts
@@ -263,7 +263,7 @@ describe("configure command", () => {
     ) as Record<string, unknown>;
     expect(provider.name).toBe("custom_poe");
     expect(provider.api_key_env).toBe("CUSTOM_POE_API_KEY");
-    expect(provider.models).toBeUndefined();
+    expect(provider.models).toEqual([]);
   });
 
   it("prompts for an agent when core.defaultAgent is configured without --yes", async () => {

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -70,10 +70,6 @@ export const GOOSE_INSTALL_DEFINITION: ServiceInstallDefinition = {
   successMessage: "Installed Goose CLI."
 };
 
-/**
- * The models written into Goose's custom provider catalog: just the selected
- * model when configure resolved one, otherwise the offered defaults.
- */
 function buildCustomProvider(
   baseUrl: string
 ): ConfigObject {
@@ -154,11 +150,17 @@ export const gooseService = createProvider<
       fileMutation.backup({ target: CUSTOM_PROVIDER_FILE, once: true }),
       fileMutation.backup({ target: GOOSE_CONFIG_FILE, once: true }),
       fileMutation.backup({ target: GOOSE_SECRETS_FILE, once: true }),
-      configMutation.merge({
+      configMutation.transform({
         target: CUSTOM_PROVIDER_FILE,
-        value: (ctx) => {
+        transform: (document, ctx) => {
           const { provider } = (ctx ?? {}) as unknown as GooseConfigureContext;
-          return buildCustomProvider(provider?.baseUrl ?? "");
+          const content: ConfigObject = {
+            ...document,
+            ...buildCustomProvider(provider?.baseUrl ?? ""),
+            // Goose requires the catalog field even when selection is per run.
+            models: document.models ?? []
+          };
+          return { content, changed: JSON.stringify(document) !== JSON.stringify(content) };
         }
       }),
       configMutation.merge({

--- a/src/providers/providers.test.ts
+++ b/src/providers/providers.test.ts
@@ -2195,7 +2195,7 @@ describe("goose service", () => {
     expect(provider.base_url).toBe("https://api.poe.com/v1/chat/completions");
     expect(provider.api_key_env).toBe("CUSTOM_POE_API_KEY");
     expect(provider.headers).toBeUndefined();
-    expect(provider.models).toBeUndefined();
+    expect(provider.models).toEqual([]);
 
     const secrets = parseYaml(await mockFsObj.readFile(secretsPath, "utf8")) as Record<
       string,
@@ -2225,6 +2225,18 @@ describe("goose service", () => {
     expect(
       ((config.extensions as Record<string, unknown>).custom as Record<string, unknown>).enabled
     ).toBe(true);
+  });
+
+  it("preserves an existing Goose provider model catalog", async () => {
+    const models = [{ name: "personal-model", context_limit: 64000 }];
+    await mockFsObj.mkdir(path.dirname(providerPath), { recursive: true });
+    await mockFsObj.writeFile(providerPath, JSON.stringify({ models, headers: { "X-Custom": "keep" } }), "utf8");
+
+    await configureGoose();
+
+    const provider = JSON.parse(await mockFsObj.readFile(providerPath, "utf8"));
+    expect(provider.models).toEqual(models);
+    expect(provider.headers).toEqual({ "X-Custom": "keep" });
   });
 
   it("uses provider.baseUrl when building the custom provider config", async () => {


### PR DESCRIPTION
The review workflow and live-agent checks omit runtime model selection, so native CLI defaults can select models unavailable on Poe. Fresh Kimi configuration also lacks a registered model, and Goose rejects its generated provider configuration because the required `models` field is absent.

Pass explicit supported runtime models while preserving review and per-agent overrides. Reviews use the repository variable `POE_CODE_REVIEW_MODEL` with `gpt-5.4` as fallback; live checks honor `POE_CODE_E2E_<AGENT>_MODEL`. Kimi forwards its local alias unchanged and registers the selected model only in the isolated fixture, preserving existing provider/model entries. Goose's ACP fixture receives its selected `GOOSE_MODEL`; normal Goose configuration now supplies an empty required catalog only when absent, preserving user catalog entries and headers. No global model default is written.

Host E2E backends invoke the built MCP fixture through Node and an absolute path because installation before build can leave the workspace bin link missing. Podman retains its installed executable. A separate test-only commit retains the HTTP server's subtype during registration without changing its runtime assertions.

The runtime defaults were verified with the read-only [Poe catalog](https://api.poe.com/v1/models). Kimi follows its [registered-alias contract](https://github.com/MoonshotAI/kimi-cli/blob/main/docs/en/configuration/config-files.md). The installer-selected Goose stable asset digest matches v1.50.0: its pinned [provider schema](https://github.com/aaif-goose/goose/blob/4cc49a8485f7960efeceba37ac5f572459c52c7c/crates/goose-providers/src/declarative.rs#L147) requires `models`, and its [model resolver](https://github.com/aaif-goose/goose/blob/4cc49a8485f7960efeceba37ac5f572459c52c7c/crates/goose/src/config/providers.rs#L75) honors `GOOSE_MODEL`.

This branch also includes the exact Node20 test prerequisite from #716 (`8e9fbc92113c2fe1456c6a6e03db244392a90776`) through a normal branch merge. It supplies the browser locale in test realms and uses async iteration to collect stream values while preserving existing assertions. PR716 itself still needs these runtime-model corrections; neither PR has been merged.

Validation:
- Reproduced missing model forwarding, missing executable, and missing catalog before fixing them. All 188 focused provider/CLI/fixture tests pass, including existing-catalog preservation and a real offline MCP handshake/tool result.
- Normal full build, complete E2E typecheck, and full guarded lint pass. Independent review found no actionable issues.
- Pinned native Goose with an isolated fake provider reproduced `missing field models` → `Provider not set`. Adding the required catalog makes it reach the localhost endpoint with the selected model and MCP tools. No external model/API call was used for diagnosis.
- Before integration, `792300fbb382deaca1be6d83665bae7a06d094a7` passed all 13 live E2E tests, Node22, packed APIs, and exact-head review; its E2E-blocking thread was resolved. General CI failed in the Node20 compatibility cases and two test deadlines.
- Combined head `106f9f7a044a28c84a586d02d1394f175cc96a18` passes all 139 affected browser/stream tests under Node20.20.0 and full guarded lint. Fresh combined CI passes live E2E (13/13), Node22, and packed APIs, with exact-head review approved and no unresolved review threads. The general check fails only the coverage-demo replay and tiny-MCP NodeNext DOM compiler-test deadlines (both 5000ms): 22,465 tests pass, 2 fail, and 1 is skipped. Both failures remain separately owned, without deadline changes or a flake waiver. This required check keeps the PR unready for merge.

This branch now also carries the exact two-file retained-root optimization from #717 (`344ddf40439da30819085a58d8bc94a8f301bda7`), preserving its author and source attribution. The source parent and this branch had identical `object-model.ts` blobs, so only that commit was replayed; newer release ancestry was not merged. It reuses unchanged intrinsic root references while still recursively measuring retained data on every reconciliation, with conservative fallback for restored/untracked objects.

At combined head `17400f2451dc4452cd8af953f5a788ef62fff5b8`, all 24 maintained workspace builds, 93 focused Node20 tests (including the unchanged five-second replay), and full guarded lint pass (10,577 files, zero errors/warnings, types and workflows). Fresh combined CI passes live E2E (13/13), Node22, packed public APIs, and exact-head review. General CI still fails the unchanged five-second tiny-MCP NodeNext DOM compiler test (5411ms) and coverage-demo replay (6823ms): 22,465 tests pass, 2 fail, and 1 is skipped. The hosted replay failure remains after this optimization; both failures are routed to their existing owners. This required check keeps the PR unready. The exact run uses Node20.20.2 and npm10.8.2; no rerun or deadline waiver was applied.

The curl metadata change remains separate in #714. PR #712 also depends on the reviewer model correction: its [review run](https://github.com/poe-platform/poe-code/actions/runs/34446068308) failed on the unsupported native model default. Product Goose ACP model propagation remains separate. No timeout changes, skipped tests, manual paid reruns, merge, or release are included.

### Offline runtime configuration diagnostic

Actual output captured at `42d8622629cbc8170091bdf7217d05003286c408` from configuration helpers, the Kimi argument builder, and a command recorder exercising the generated reviewer invocation. This shows default/override handling and isolated Kimi registration, not a live agent/model execution, CI pass, or product-browser screenshot.

![Offline runtime configuration and argument diagnostic](https://github.com/user-attachments/assets/f381993f-3670-41f9-b0a2-5b34a79e5d28)




