### PR TITLE
Keep browser and stream tests compatible with Node20

### DIFF
--- a/packages/safe-bash-playground/src/engine/kernel.test.ts
+++ b/packages/safe-bash-playground/src/engine/kernel.test.ts
@@ -13,6 +13,7 @@ describe("real safe-bash browser kernel", () => {
   const activeWorkers = new Set<{ terminate(): void }>();
 
   beforeAll(async () => {
+    vi.stubGlobal("navigator", { language: "en-US" });
     vi.stubGlobal(
       "Worker",
       class extends EventTarget {
@@ -28,6 +29,7 @@ describe("real safe-bash browser kernel", () => {
             const worker = new NodeWorker(
               `
             const { parentPort } = require('node:worker_threads');
+            Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { language: 'en-US' } });
             globalThis.addEventListener = (event, handler) => parentPort.on(event, data => handler({ data }));
             globalThis.postMessage = (value, transfer) => parentPort.postMessage(value, transfer);
             ${code}

--- a/packages/safe-bash-playground/src/execution-filesystem.test.ts
+++ b/packages/safe-bash-playground/src/execution-filesystem.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { createMemoryFileSystem, FsError } from "./engine/index.js";
 import type { FileSystem } from "./engine/index.js";
 import { decodeError, encodeError, hostFileSystem, remoteFileSystem } from "./execution-filesystem.js";
+
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+afterAll(() => vi.unstubAllGlobals());
 
 vi.mock("./engine/index.js", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");

--- a/packages/safe-bash-playground/src/execution.test.ts
+++ b/packages/safe-bash-playground/src/execution.test.ts
@@ -7,6 +7,8 @@ import type { ExecutionMessage } from "./execution-protocol.js";
 import { browserWorkerFixture } from "../test/browser-worker.js";
 import { setTimeout as delay } from "node:timers/promises";
 
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+
 vi.mock("virtual:safe-bash-worker-sources", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");
   return { sources: (await buildBrowserEngine({ workersOnly: true })).workerSources };

--- a/packages/safe-bash-playground/src/session.test.ts
+++ b/packages/safe-bash-playground/src/session.test.ts
@@ -3,6 +3,8 @@ import { createSession, SESSION_LIMITS } from "./session.js";
 import { sampleFiles } from "./samples.js";
 import { browserWorkerFixture } from "../test/browser-worker.js";
 
+vi.hoisted(() => vi.stubGlobal("navigator", { language: "en-US" }));
+
 vi.mock("virtual:safe-bash-worker-sources", async () => {
   const { buildBrowserEngine } = await import("./engine/build-plugin.mjs");
   return { sources: (await buildBrowserEngine({ workersOnly: true })).workerSources };

--- a/packages/safe-bash-playground/test/browser-worker.ts
+++ b/packages/safe-bash-playground/test/browser-worker.ts
@@ -18,6 +18,7 @@ export function browserWorkerFixture(executionSource: string) {
       this.worker = source.then((code) => {
         const worker = new NodeWorker(`
           const { parentPort } = require("node:worker_threads");
+          Object.defineProperty(globalThis, "navigator", { configurable: true, value: { language: "en-US" } });
           globalThis.addEventListener = (event, handler) => parentPort.on(event, data => handler({ data }));
           globalThis.postMessage = value => parentPort.postMessage(value);
           (() => { ${code} })();

--- a/packages/toolcraft/src/stream.test.ts
+++ b/packages/toolcraft/src/stream.test.ts
@@ -7,6 +7,12 @@ import {
   type ToolcraftStream
 } from "./index.js";
 
+async function collect<Value>(stream: AsyncIterable<Value>): Promise<Value[]> {
+  const values: Value[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
 describe("defineStreamCommand SDK lifecycle", () => {
   it("starts lazily and advances only when the consumer pulls", async () => {
     const produced: number[] = [];
@@ -78,7 +84,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
 
     const stream = sdk.watch({}, { onStatus: (event) => statuses.push(event) });
 
-    await expect(Array.fromAsync(stream)).resolves.toEqual([{ state: "fresh-token" }]);
+    await expect(collect(stream)).resolves.toEqual([{ state: "fresh-token" }]);
     expect(statuses).toEqual([
       { type: "reconnecting", message: "Refreshing credentials" }
     ]);
@@ -95,7 +101,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
     });
     const sdk = createSDK(defineGroup({ name: "devices", children: [watch] }));
 
-    await expect(Array.fromAsync(sdk.watch({}))).rejects.toThrow("state");
+    await expect(collect(sdk.watch({}))).rejects.toThrow("state");
   });
 
   it("propagates terminal errors and releases resources once", async () => {
@@ -115,7 +121,7 @@ describe("defineStreamCommand SDK lifecycle", () => {
     });
     const sdk = createSDK(defineGroup({ name: "devices", children: [watch] }));
 
-    await expect(Array.fromAsync(sdk.watch({}))).rejects.toThrow("connection lost");
+    await expect(collect(sdk.watch({}))).rejects.toThrow("connection lost");
     expect(cleanup).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
The playground tests load the real browser engine in Node processes and Worker fixtures, where Node20 lacks `navigator.language`. The stream lifecycle tests also call `Array.fromAsync`, which is unavailable in Node20.

Supply the browser locale in those test realms and collect stream values with `for await`. The existing execution, cancellation, schema-error, and cleanup assertions remain in place.

Validation:
- Node20.20.0: four browser test files passed, 134 tests total; stream lifecycle tests passed 5/5.
- Maintained playground build passed. Guarded repository lint passed with 10,571 files, zero errors/warnings, and 25 boundary receipts.

This prerequisite addresses the browser import and stream API failures observed in #715 and the other active PRs. The separate replay-equivalence and tiny-MCP compiler test deadlines remain under investigation; this change does not alter their deadlines or assertions.
