### PR TITLE
perf(safe-js): reuse unchanged intrinsic retained roots

### DIFF
--- a/packages/safe-js/src/interp/intrinsic-retained-roots-cache.test.ts
+++ b/packages/safe-js/src/interp/intrinsic-retained-roots-cache.test.ts
@@ -1,0 +1,119 @@
+import { expect, it, vi } from "vitest";
+import { Budget, SandboxError } from "./budget.js";
+import { accessorAdapter } from "./accessors.js";
+import { completeIntrinsicObjectInitialization, createIntrinsicObject, materializeFunctionProperties, registerIntrinsicFunction, registerIntrinsicObject, releaseObjectPrototype, setSandboxPrototype } from "./object-model.js";
+import { createSandboxClosure, measureSandboxData, reconcileCompiledValues, type SandboxObject } from "./values.js";
+
+it("reuses the collected roots while still rejecting nested growth above the memory limit", () => {
+  const budget = new Budget({ dataSize: 100 });
+  const registration = vi.spyOn(budget, "setRetainedValues");
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  const collect = registration.mock.calls.at(-1)![1]!;
+  const nested = { payload: "small" };
+  root.extra = nested;
+  try {
+    const roots = collect();
+    expect([...roots]).toEqual(["extra", nested]);
+    expect(collect()).toBe(roots);
+    reconcileCompiledValues(budget, []);
+    nested.payload = "x".repeat(200);
+    expect(collect()).toBe(roots);
+    expect(() => reconcileCompiledValues(budget, [])).toThrow(SandboxError);
+  } finally { registration.mockRestore(); releaseObjectPrototype(budget); }
+});
+
+it("refreshes collected roots after define, delete, accessors, prototype changes and baseline completion", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  const read = vi.fn(() => undefined);
+  const getter = createSandboxClosure({ guest: true, call: read, retainedValues: () => ["captured"] });
+  const parent = { payload: "parent" };
+  try {
+    expect([...budget.retainedValues()]).toEqual([]);
+    Object.defineProperty(root, "extra", { value: "defined", configurable: true });
+    expect([...budget.retainedValues()]).toEqual(["extra", "defined"]);
+    delete root.extra;
+    expect([...budget.retainedValues()]).toEqual([]);
+    Object.defineProperty(root, "extra", { get: accessorAdapter(getter, "get"), configurable: true });
+    expect([...budget.retainedValues()]).toEqual(["extra", undefined, getter]);
+    setSandboxPrototype(root, parent, budget);
+    expect([...budget.retainedValues()]).toEqual([parent, "extra", undefined, getter]);
+    completeIntrinsicObjectInitialization(budget, root);
+    expect([...budget.retainedValues()]).toEqual([]);
+    delete root.extra;
+    setSandboxPrototype(root, null, budget);
+    expect([...budget.retainedValues()]).toEqual([null]);
+    expect(read).not.toHaveBeenCalled();
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("remeasures mutations through an untracked restored property-table alias", () => {
+  const budget = new Budget();
+  const method = createSandboxClosure({ guest: true, name: "restored", call: () => undefined });
+  const restored: SandboxObject = { name: "restored" };
+  expect(materializeFunctionProperties(method, restored)).toBe(restored);
+  registerIntrinsicFunction(budget, method);
+  try {
+    expect([...budget.retainedValues()]).toEqual([]);
+    restored.extra = "first";
+    expect([...budget.retainedValues()]).toEqual(["extra", "first"]);
+    restored.extra = "longer";
+    expect(measureSandboxData(budget.retainedValues())).toBe(11);
+    delete restored.extra;
+    expect([...budget.retainedValues()]).toEqual([]);
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("keeps committed roots after failed definitions and deletions", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  try {
+    Object.defineProperty(root, "locked", { value: "retained", configurable: false, writable: false });
+    expect([...budget.retainedValues()]).toEqual(["locked", "retained"]);
+    expect(Reflect.defineProperty(root, "locked", { value: "replacement" })).toBe(false);
+    expect(Reflect.deleteProperty(root, "locked")).toBe(false);
+    Object.preventExtensions(root);
+    expect(Reflect.defineProperty(root, "new", { value: "uncommitted" })).toBe(false);
+    expect([...budget.retainedValues()]).toEqual(["locked", "retained"]);
+  } finally { releaseObjectPrototype(budget); }
+});
+
+it("keeps both budgets current and ignores rejected prototype mutations", () => {
+  const first = new Budget();
+  const second = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(first, root);
+  registerIntrinsicObject(second, root);
+  const parent = { retained: "parent" };
+  try {
+    expect([...first.retainedValues()]).toEqual([]);
+    expect([...second.retainedValues()]).toEqual([]);
+    setSandboxPrototype(root, parent);
+    expect([...first.retainedValues()]).toEqual([parent]);
+    expect([...second.retainedValues()]).toEqual([parent]);
+    expect(setSandboxPrototype(parent, root, undefined, false)).toBe(false);
+    Object.preventExtensions(root);
+    expect(setSandboxPrototype(root, {}, undefined, false)).toBe(false);
+    expect([...first.retainedValues()]).toEqual([parent]);
+    releaseObjectPrototype(first);
+    expect([...second.retainedValues()]).toEqual([parent]);
+  } finally { releaseObjectPrototype(first); releaseObjectPrototype(second); }
+});
+
+it("keeps root snapshots stable when a retained callback mutates the next collection", () => {
+  const budget = new Budget();
+  const root = createIntrinsicObject();
+  registerIntrinsicObject(budget, root);
+  root.first = createSandboxClosure({ call: () => undefined, retainedValues: () => {
+    root.later = "z".repeat(100);
+    return [];
+  } });
+  root.later = "initial";
+  try {
+    expect(measureSandboxData(budget.retainedValues())).toBe(18);
+    expect(measureSandboxData(budget.retainedValues())).toBe(111);
+  } finally { releaseObjectPrototype(budget); }
+});

--- a/packages/safe-js/src/interp/object-model.ts
+++ b/packages/safe-js/src/interp/object-model.ts
@@ -42,11 +42,17 @@ const functionPropertyRevisions = new WeakMap<object, {
 const trackedIntrinsicObjects = new WeakSet<object>();
 const prototypes = new WeakMap<object, object | null>();
 const trackedPrototypes = new WeakMap<object, { current: object | null }>();
+// Identity tokens cannot overflow. Unrelated mutations conservatively invalidate
+// all groups without retaining subscriber lists or their owning budgets.
+let intrinsicMutationToken = {};
 
 function storePrototype(value: object, prototype: object | null): void {
   prototypes.set(value, prototype);
   const tracked = trackedPrototypes.get(value);
-  if (tracked !== undefined) tracked.current = prototype;
+  if (tracked !== undefined && tracked.current !== prototype) {
+    tracked.current = prototype;
+    intrinsicMutationToken = {};
+  }
 }
 const intrinsicPrototypes = new WeakMap<Budget, SandboxObject>();
 const boxedPrototypes = new WeakMap<Budget, Map<BoxedKind, SandboxObject>>();
@@ -140,12 +146,18 @@ function trackPropertyTable(properties: SandboxObject): SandboxObject {
   const tracked = new Proxy(properties, {
     defineProperty(target, key, descriptor) {
       const changed = Reflect.defineProperty(target, key, descriptor);
-      if (changed) state.revision++;
+      if (changed) {
+        state.revision++;
+        intrinsicMutationToken = {};
+      }
       return changed;
     },
     deleteProperty(target, key) {
       const changed = Reflect.deleteProperty(target, key);
-      if (changed) state.revision++;
+      if (changed) {
+        state.revision++;
+        intrinsicMutationToken = {};
+      }
       return changed;
     }
   });
@@ -293,6 +305,7 @@ export function completeIntrinsicObjectInitialization(budget: Budget, value: San
     const record = records.find(record => record.target === value);
     if (record === undefined) continue;
     Object.assign(record, captureIntrinsicRecords([value])[0]);
+    intrinsicMutationToken = {};
     return;
   }
 }
@@ -371,7 +384,14 @@ function trackIntrinsicState(
     retainedRecords.push(record);
   }
   if (retainedRecords.length === 0) return;
+  const cacheable = retainedRecords.every(record => record.revision !== undefined);
+  let capturedToken: object | undefined;
+  let capturedRoots: unknown[] = [];
   budget.setRetainedValues(root, () => {
+    // O(1) root collection when tracked tables are unchanged. Only references
+    // are reused: measurement still recursively visits their current contents.
+    // Restored/untracked tables must always take the conservative scan below.
+    if (cacheable && capturedToken === intrinsicMutationToken) return capturedRoots;
     // Capture every change before measurement invokes retained-value callbacks.
     const retained: unknown[] = [];
     for (const record of retainedRecords) {
@@ -389,6 +409,10 @@ function trackIntrinsicState(
         record.capturedRevision = revision?.revision ?? -1;
       }
       for (const item of record.captured) retained.push(item);
+    }
+    if (cacheable) {
+      capturedRoots = retained;
+      capturedToken = intrinsicMutationToken;
     }
     return retained;
   });


### PR DESCRIPTION
SafeJS repeatedly rebuilds the same intrinsic root-reference lists during memory reconciliation, including every replay segment. This change reuses those lists while every object in the group has a tracked property table and nothing has changed. Nested values are still recursively measured on every reconciliation; memory, step, and replay deadlines are unchanged.

Successful property/prototype mutations and baseline completion invalidate the lists. Restored or otherwise untracked tables retain the conservative scan. Callback snapshots remain stable and releasing a budget removes its retained source.

Validation:
- Six new regressions cover reuse with nested memory-limit rejection, descriptors/accessors, deletion, prototypes, baseline completion, restored aliases, failed mutations, multiple budgets, and callback snapshots.
- 248 focused accounting and snapshot tests passed; the maintained agent-harness build closure passed across 24 workspaces.
- The unchanged Node20 coverage-demo replay passed in 1.29 seconds under its original five-second deadline. This is a local result, not a CI performance guarantee.
- Independent source review cleared the exact two-file diff. Focused test typing and repository ESLint passed (10,590 files, zero errors/warnings).

This is a separate prerequisite for the replay timeout observed in PR715 and PR716. It is not included in the frozen safe-bash536 consumer build and does not address the independent tiny-MCP compiler-test timeout.


## Hosted CI at this head

Node22 and packed public API checks passed. The shared Node20 job still failed the original five-second coverage-demo replay test, so the local improvement does **not** establish that the hosted deadline is resolved. The same job also reported the tiny-MCP NodeNext DOM deadline and the browser-fixture/Array.fromAsync compatibility failures owned by separate prerequisites. The provider E2E and external review automation failed their existing model/setup paths. No deadlines or accounting checks were relaxed, and no paid rerun was requested. This PR remains a draft while those failures are addressed.

## Saved local verification evidence

This non-UI diagnostic was rendered from saved local logs for head `344ddf40439da30819085a58d8bc94a8f301bda7` and captured with Playwright CLI. It records the reference-reuse RED case, 248 passing accounting/snapshot tests, the original focused replay test passing in 1.29 seconds under its unchanged five-second deadline, and saved build/type/lint results. It is not a product interaction or a fresh benchmark run; local results do not establish hosted CI timing.

![Saved local retained-root verification results](https://github.com/user-attachments/assets/9292c092-311a-4240-b1ea-9ff0efdc34e4)
