### PR TITLE
fix(safe-bash): classify generated compression declarations

### DIFF
--- a/packages/safe-bash/scripts/integration-inputs.test.mjs
+++ b/packages/safe-bash/scripts/integration-inputs.test.mjs
@@ -2867,3 +2867,37 @@ test("import-origin R2 operational inventory pin rejects missing swapped and rel
     assert.ok(reads.every(path => path === "/package/integration-lint-inventory.json"));
   }
 });
+
+test("production declaration census preserves build coverage and authenticates bytes", async () => {
+  const { mergeBuildDeclarationInventory } = await import("./typecheck-inputs.mjs");
+  const { verifyInventory } = await import("../tests/plugins/qualified-current-release/inventory-check.mjs");
+  const paths = ["bz2", "xz", "zstd"].map(name => `src/commands/bytes/compression/native/generated/${name}.d.mts`);
+  const read = () => Buffer.from("export {};\n");
+  const original = { entries: [], counts: {} };
+  const inventory = mergeBuildDeclarationInventory(original, { include: paths, exclude: ["tests", "dist", "node_modules"] }, paths, read);
+  assert.deepEqual(original, { entries: [], counts: {} });
+  assert.deepEqual(verifyInventory(inventory, paths, [], [], read), { declaration: 3 });
+  assert.throws(() => verifyInventory(inventory, paths, [], [], () => Buffer.from("changed")), /inventory changed/);
+  assert.throws(() => verifyInventory(inventory, [...paths, "src/unrouted.mts"], [], [], read), /classify new paths/);
+});
+
+test("production declaration admission refuses missing or excluded build inputs", async () => {
+  const { mergeBuildDeclarationInventory } = await import("./typecheck-inputs.mjs");
+  const paths = ["bz2", "xz", "zstd"].map(name => `src/commands/bytes/compression/native/generated/${name}.d.mts`);
+  const admit = (build, tracked = paths) => mergeBuildDeclarationInventory({ entries: [], counts: {} }, build, tracked, () => Buffer.from("export {};\n"));
+  assert.throws(() => admit({ include: paths.slice(1) }), /explicit build input/);
+  assert.throws(() => admit({ include: paths }, paths.slice(1)), /must be tracked/);
+  assert.throws(() => admit({ include: paths, exclude: ["src/commands"] }), /excluded from build/);
+  assert.throws(() => admit({ include: paths, exclude: ["src/**"] }), /explicit exclusion paths/);
+  assert.throws(() => admit({ include: paths, exclude: [paths[0]] }), /excluded from build/);
+  for (const exclusion of ["./src/commands", ".", "src/../src/commands", "src//commands", "src/commands/", "../src", "/src", "src\\commands"]) {
+    assert.throws(() => admit({ include: paths, exclude: [exclusion] }), /canonical relative exclusion paths/);
+  }
+});
+
+test("production declaration admission preserves regular-input refusal", async () => {
+  const { mergeBuildDeclarationInventory } = await import("./typecheck-inputs.mjs");
+  const paths = ["bz2", "xz", "zstd"].map(name => `src/commands/bytes/compression/native/generated/${name}.d.mts`);
+  const refusal = new Error("held or non-regular input");
+  assert.throws(() => mergeBuildDeclarationInventory({ entries: [], counts: {} }, { include: paths }, paths, () => { throw refusal; }), error => error === refusal);
+});

--- a/packages/safe-bash/scripts/typecheck-inputs.mjs
+++ b/packages/safe-bash/scripts/typecheck-inputs.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import { consumerGroups, currentConsumerPaths, currentSourceConsumerGroups, negativeGroups } from "../tests/plugins/qualified-current-release/consumers.mjs";
 import { verifyInventory } from "../tests/plugins/qualified-current-release/inventory-check.mjs";
 import { verifyStagedTypeInputs } from "./typecheck-staged-inputs.mjs";
@@ -30,6 +30,23 @@ export function mergeStandaloneInventory(inventory, sealedEntries) {
     entries: [...inventory.entries, ...additions],
     counts: { ...inventory.counts, "frozen-evidence": inventory.counts["frozen-evidence"] + additions.length },
   };
+}
+
+export function mergeBuildDeclarationInventory(inventory, build, tracked, read) {
+  const paths = ["bz2", "xz", "zstd"].map(name => `src/commands/bytes/compression/native/generated/${name}.d.mts`);
+  const entries = paths.map(path => {
+    assert.ok(tracked.includes(path), `production declaration must be tracked: ${path}`);
+    assert.ok(build.include?.includes(path), `production declaration must remain an explicit build input: ${path}`);
+    for (const exclusion of build.exclude ?? []) {
+      assert.ok(typeof exclusion === "string" && exclusion.length > 0 && !exclusion.includes("\\") && !posix.isAbsolute(exclusion) && posix.normalize(exclusion) === exclusion && exclusion !== "." && exclusion !== ".." && !exclusion.startsWith("../") && !exclusion.endsWith("/"), "build declaration admission requires canonical relative exclusion paths");
+      assert.ok(!["*", "?", "[", "{"].some(character => exclusion.includes(character)), "build declaration admission requires explicit exclusion paths");
+      const prefix = exclusion.endsWith("/") ? exclusion : `${exclusion}/`;
+      assert.ok(path !== exclusion && !path.startsWith(prefix), `production declaration excluded from build: ${path}`);
+    }
+    assert.ok(!inventory.entries.some(entry => entry.path === path), `duplicate production declaration route: ${path}`);
+    return { path, classification: "declaration", sha256: sha256(read(path)), qualifiedCoverage: "tsconfig.build.json explicit production declaration input" };
+  });
+  return { ...inventory, entries: [...inventory.entries, ...entries], counts: { ...inventory.counts, declaration: (inventory.counts.declaration ?? 0) + entries.length } };
 }
 
 export function verifyAdmittedStandaloneInventory(inventory, tracked, currentPaths, negativePaths, read, boundaries) {
@@ -74,7 +91,10 @@ export function verifyTypecheckInputs(root, fileSystem = fs) {
   }
   const tracked = execFileSync("git", ["ls-files", "-z"], { cwd: root, maxBuffer: 32 * 1024 * 1024 }).toString().split("\0").filter(Boolean);
   for (const entry of staged.entries) assert.ok(tracked.includes(entry.path) && tracked.includes(entry.owner.path), `staged input and owning manifest must be tracked: ${entry.path}`);
-  const inventory = mergeStandaloneInventory(originalInventory, integrationTypes.standaloneEntries);
+  const inventory = mergeBuildDeclarationInventory(
+    mergeStandaloneInventory(originalInventory, integrationTypes.standaloneEntries),
+    JSON.parse(read("tsconfig.build.json")), tracked, read,
+  );
   const classified = new Set(inventory.entries.map(entry => entry.path));
   const unknown = tracked.filter(path => path.endsWith(".mts") && !classified.has(path));
   assert.equal(unknown.length, 0, `Unclassified current .mts inputs require an explicit existing-inventory route: ${unknown.join(", ")}`);


### PR DESCRIPTION
The maintained type-input census rejected the generated bz2, xz, and zstd declarations even though the production build explicitly includes them. This adds their current production declaration route without changing the sealed historical inventory or removing compiler inputs.

Admission requires tracked, regular files, explicit build inclusion, and canonical exclusion paths that do not exclude the declarations. The existing census still rejects unknown inputs and verifies declaration bytes. Regression coverage includes exclusion aliases, missing coverage, changed declaration bytes, and read refusal.

Validation: original inventory check reproduced the three-input assertion; corrected inventory passes. All 310 maintained runner tests pass with no skips on Node 22.22.0. Maintained root ESLint passes with complete coverage and no errors or warnings. These results do not claim a complete production build or compiler qualification.

### Screenshot

Local diagnostic capture of the reviewed uncommitted patch on base `52a76cc880cbcc6088ccd5dc65b70e0a86c24b90`: original refusal, three focused tests, and corrected inventory census. This image predates the broader 310-test runner result.

![Declaration inventory diagnostic](https://github.com/user-attachments/assets/3b3472f6-15fd-47c6-8258-01d9fd843eff)
