### PR TITLE
fix(safe-bash): drain admitted owned output writes on close

### DIFF
--- a/packages/safe-bash/src/contracts/output.ts
+++ b/packages/safe-bash/src/contracts/output.ts
@@ -17,6 +17,7 @@ export function createOutputOperation(context: Pick<CommandContext, "signal" | "
   const capability = destination.ownedOutput;
   const callbacks: InvocationCleanup[] = [];
   const children: OutputOperation[] = [];
+  const writes = new Set<Promise<void>>();
   const closedReason = new Error("Output operation is closed");
   let accepting = true;
   let drain: Promise<void> | undefined;
@@ -30,7 +31,7 @@ export function createOutputOperation(context: Pick<CommandContext, "signal" | "
     accepting = false;
     drain = Promise.resolve().then(async () => {
       try {
-        const results = await Promise.allSettled(callbacks.map(async cleanup => cleanup()));
+        const results = await Promise.allSettled([...writes, ...callbacks.map(async cleanup => cleanup())]);
         const failures = results.filter(result => result.status === "rejected").map(result => result.reason);
         if (failures.length === 1) throw failures[0];
         if (failures.length) throw new AggregateError(failures, "Output operation cleanup failed");
@@ -79,7 +80,15 @@ export function createOutputOperation(context: Pick<CommandContext, "signal" | "
       ...(destination[outputFailure] ? { [outputFailure]: destination[outputFailure] } : {}),
       async write(chunk) {
         assertOpen();
-        await writeBytes(capability ?? destination, chunk, signal);
+        if (!capability) return writeBytes(destination, chunk, signal);
+        let settled!: () => void;
+        const admitted = new Promise<void>(resolve => { settled = resolve; });
+        writes.add(admitted);
+        // Cancellation can settle the caller while the owned destination is still writing.
+        const pending = writeBytes(capability, chunk);
+        const finish = (): void => { writes.delete(admitted); settled(); };
+        void pending.then(finish, finish);
+        await wait(pending);
       },
     },
     registerCleanup,

--- a/packages/safe-bash/tests/shell/owned-output-drain.test.ts
+++ b/packages/safe-bash/tests/shell/owned-output-drain.test.ts
@@ -47,6 +47,84 @@ async function turns(): Promise<void> {
   for (let index = 0; index < 8; index++) await setImmediate();
 }
 
+for (const owned of [true, false]) {
+  test(`output operation drains only explicitly owned writes after cancellation: ${owned}`, async () => {
+    const caller = new AbortController(), entered = deferred(), gate = deferred();
+    let completed = false, closed = false;
+    const write = async () => {
+      entered.resolve();
+      try { await gate.promise; throw new Error("late write failure"); }
+      finally { completed = true; }
+    };
+    const operation = createOutputOperation({ signal: caller.signal }, {
+      write,
+      ...(owned ? { ownedOutput: { consumerClosed: new AbortController().signal, write } } : {}),
+    });
+    const writing = assert.rejects(operation.output.write(Uint8Array.of(65)), reason => reason === false);
+    await entered.promise;
+    caller.abort(false);
+    const closing = operation.close().then(() => { closed = true; });
+    try {
+      await writing;
+      await turns();
+      assert.equal(closed, !owned);
+      assert.equal(completed, false);
+    } finally {
+      gate.resolve();
+      await closing;
+      await turns();
+    }
+    assert.equal(completed, true);
+  });
+}
+
+test("output operation closes all admitted writes and runs cleanup that releases them", async () => {
+  const first = deferred(), second = deferred(), entered = deferred();
+  let calls = 0, closed = false;
+  const operation = createOutputOperation({ signal: new AbortController().signal }, {
+    async write() { assert.fail("owned route required"); },
+    ownedOutput: { consumerClosed: new AbortController().signal, async write() {
+      if (++calls === 1) await first.promise;
+      else { entered.resolve(); await second.promise; }
+    } },
+  });
+  operation.registerCleanup(() => { first.resolve(); });
+  const writes = [operation.output.write(Uint8Array.of(1)), operation.output.write(Uint8Array.of(2))];
+  await entered.promise;
+  const closing = operation.close().then(() => { closed = true; });
+  try {
+    await writes[0];
+    await turns();
+    assert.equal(closed, false);
+    await assert.rejects(operation.output.write(Uint8Array.of(3)), /closed/);
+    assert.equal(calls, 2);
+  } finally {
+    second.resolve();
+    await Promise.all([...writes, closing]);
+  }
+});
+
+test("output operation drains a write that closes its scope during admission", async () => {
+  const gate = deferred();
+  let closing: Promise<void> | undefined, closed = false;
+  const operation = createOutputOperation({ signal: new AbortController().signal }, {
+    async write() { assert.fail("owned route required"); },
+    ownedOutput: { consumerClosed: new AbortController().signal, async write() {
+      closing = operation.close().then(() => { closed = true; });
+      await gate.promise;
+    } },
+  });
+  const writing = operation.output.write(Uint8Array.of(65));
+  try {
+    assert.ok(closing);
+    await turns();
+    assert.equal(closed, false);
+  } finally {
+    gate.resolve();
+    await Promise.all([writing, closing]);
+  }
+});
+
 for (const command of ["writer", "forward"]) {
   for (const reason of [false, 0, "", null, "dispose"] as const) {
     test(`${command}: enrolled write drains before caller ${JSON.stringify(reason)}`, async () => {


### PR DESCRIPTION
When cancellation arrives during an explicitly owned output write, an output operation can finish cleanup before that write settles. This lets curl return or shell disposal complete while its destination is still writing.

Track writes when they are admitted and drain them together with cleanup callbacks. Cancellation still reaches the caller promptly, opaque destinations retain their existing behavior, and cleanup can release a pending owned write without deadlocking.

Publication is rebased onto upstream main ede5985e5e2b35b38eebd0faaeb3ed6a390493e9, including the separately landed provider prerequisites. The two fix files retain their exact reviewed hashes. The validation below remains bound to the preserved52a source/artifact; fresh broad CI qualifies the rebased head. No stale compiled workspace outputs are being presented as current-main validation.

Validation on the exact 52a76 source basis:

- 99 focused output/contract tests passed, including false cancellation reasons, multiple pending writes, and close invoked during write admission.
- Built-package consumer checks passed: 26 built groups, three source groups, and three expected negative cases.
- Source-and-tests typecheck passed after the maintained SafeJS declaration build and canonical filesystem rematerialization. The four composed source files, lock, 19 retained filesystem outputs, and 54 shell browser outputs retained their verified hashes.
- Full guarded ESLint passed: all 10,673 configured files, zero errors or warnings. Root lint types failed because unrelated workspace declarations were absent; workflow lint was not run. The user explicitly authorized publishing without repeating broad local validation. The normal commit succeeded; this isolated Git worktree has no configured hook or executable default hooks. GitHub CI remains required.
- Fresh packed real-Shell lifetime verification passed all three unchanged tests (19 assertions, 1.54s): owned caller cancellation, owned Shell disposal, and opaque-output control. The historical packed536 two-failure result is preserved. This validates the standalone output fix, not the final platform composition or hosted service.

The inventory prerequisite was separately composed for qualification; it is not part of this two-file fix. Its historical local patch has since been superseded upstream by be65352069a70ec23a8be034babd60ab807bd0e2. The standalone proof does not include the full platform composition or PR714 response-mode changes.

![Diagnostic proof of the owned-output regression](https://github.com/user-attachments/assets/6469c38a-5a92-406c-85f0-1f49dd3e5d75)

Historical diagnostic evidence: upstream536 source baseline had two failing owned-output cases and one passing opaque-output control; the fix passed 99 focused source tests. This image is not a product UI, packed-runtime, or Cloudflare-service proof. It binds production SHA256 f345e2d19cf1be9e1ba935a72ff7656e3383f9354483b24c471770c85b79f5ec and test SHA256 1f8f7a02e7df80a7f4860e0248eac9c5b988d6ea6e64c1e179b2d9eaf2bd0821.



### Current diagnostic test evidence

![after: Diagnostic test evidence](https://github.com/user-attachments/assets/7c525a32-ad1b-410e-b415-7a26b0c387bc)

Rendered from the saved current52a focused99PASS log and fresh packed actualShell3PASS log. This is diagnostic test evidence, not product UI, final48 qualification, or hosted Cloudflare proof. Image SHA256 22eb7a408f6b209beac7f02d46b2bad82e7836baed66dafd0653863b8abcbd40.

