### PR TITLE
test(safe-js): verify each replay checkpoint independently

### DIFF
--- a/packages/safe-js/test/ppr2-integration-adjudication.test.ts
+++ b/packages/safe-js/test/ppr2-integration-adjudication.test.ts
@@ -39,8 +39,16 @@ afterEach(() => {
 });
 
 describe("independent ordered PPR2 fresh writer continuations", () => {
-  it.each(originalScenarios)(
-    "$id: native trace, public/signal/completed checkpoints and recapture",
+  it.each(
+    originalScenarios.flatMap((scenario) =>
+      ["public", "signal", "completed"].map((checkpoint, captureIndex) => ({
+        ...scenario,
+        checkpoint,
+        captureIndex
+      }))
+    )
+  )(
+    "$id / $checkpoint: native trace, checkpoint and recapture",
     async (scenario) => {
       const nativeHost = makeFixture(scenario.id, true, scenario.policy);
       const AsyncFunction = Object.getPrototypeOf(async () => undefined).constructor;
@@ -105,40 +113,40 @@ describe("independent ordered PPR2 fresh writer continuations", () => {
       expect(original.returnValue).toEqual(native);
       expect(host.calls).toEqual(nativeHost.calls);
       captures.push(await dump(execution));
-      for (const [index, bytes] of captures.entries()) {
-        const snapshot = restore(JSON.parse(bytes), { source: scenario.source });
-        expect(snapshot.executionSemantics).toBe(expectedFresh);
-        expect(snapshot.version).toBe(2);
-        const before = JSON.stringify(snapshot);
-        const rebound = makeFixture(scenario.id, false, scenario.policy);
-        const requests: HostCallResumeRequest[] = [];
-        const resumed = await run(scenario.source, {
-          snapshot,
-          bindings: rebound.bindings,
-          budget: new Budget({ maxSteps: 150_000 }),
-          hostCallResumeProvider: receiptsProvider(original.snapshot.hostCalls ?? [], requests)
-        });
-        expect(resumed.ok).toBe(true);
-        if (!resumed.ok) throw Error(resumed.error.message);
-        expect(resumed.returnValue).toEqual(native);
-        expect(rebound.calls).toEqual(index === 2 ? [] : scenario.resumeCalls);
-        expect(requests).toHaveLength(index < 2 && scenario.policy === "read-side-effect" ? 1 : 0);
-        expect(JSON.stringify(snapshot)).toBe(before);
-        const recaptured = restore(JSON.parse(await dump(resumed)), { source: scenario.source });
-        expect(recaptured.executionSemantics).toBe(expectedFresh);
-        const finalHost = makeFixture(scenario.id, false, scenario.policy);
-        const finalProvider = vi.fn();
-        const final = await run(scenario.source, {
-          snapshot: recaptured,
-          bindings: finalHost.bindings,
-          hostCallResumeProvider: finalProvider
-        });
-        expect(final.ok).toBe(true);
-        if (!final.ok) throw Error(final.error.message);
-        expect(final.returnValue).toEqual(native);
-        expect(finalHost.calls).toEqual([]);
-        expect(finalProvider).not.toHaveBeenCalled();
-      }
+      const index = scenario.captureIndex;
+      const bytes = captures[index]!;
+      const snapshot = restore(JSON.parse(bytes), { source: scenario.source });
+      expect(snapshot.executionSemantics).toBe(expectedFresh);
+      expect(snapshot.version).toBe(2);
+      const before = JSON.stringify(snapshot);
+      const rebound = makeFixture(scenario.id, false, scenario.policy);
+      const requests: HostCallResumeRequest[] = [];
+      const resumed = await run(scenario.source, {
+        snapshot,
+        bindings: rebound.bindings,
+        budget: new Budget({ maxSteps: 150_000 }),
+        hostCallResumeProvider: receiptsProvider(original.snapshot.hostCalls ?? [], requests)
+      });
+      expect(resumed.ok).toBe(true);
+      if (!resumed.ok) throw Error(resumed.error.message);
+      expect(resumed.returnValue).toEqual(native);
+      expect(rebound.calls).toEqual(index === 2 ? [] : scenario.resumeCalls);
+      expect(requests).toHaveLength(index < 2 && scenario.policy === "read-side-effect" ? 1 : 0);
+      expect(JSON.stringify(snapshot)).toBe(before);
+      const recaptured = restore(JSON.parse(await dump(resumed)), { source: scenario.source });
+      expect(recaptured.executionSemantics).toBe(expectedFresh);
+      const finalHost = makeFixture(scenario.id, false, scenario.policy);
+      const finalProvider = vi.fn();
+      const final = await run(scenario.source, {
+        snapshot: recaptured,
+        bindings: finalHost.bindings,
+        hostCallResumeProvider: finalProvider
+      });
+      expect(final.ok).toBe(true);
+      if (!final.ok) throw Error(final.error.message);
+      expect(final.returnValue).toEqual(native);
+      expect(finalHost.calls).toEqual([]);
+      expect(finalProvider).not.toHaveBeenCalled();
     }
   );
 


### PR DESCRIPTION
The generator workflow (`co`) runs seven interpreter executions inside one five-second test. The exact PR719 focused file reproduces its CI timeout. Phase tracing measured 6.78 seconds cumulatively, with each interpreter run around 0.8–1.1 seconds; snapshot capture adds about 20–30 milliseconds.

Test each scenario's public, signal, and completed checkpoint as a complete independent case. Each gets fresh native execution and setup, preserves all capture validations, and verifies its selected replay, recapture, snapshot immutability, receipts, and absence of repeated host effects. Runtime behavior, timeouts, concurrency, and assertions are unchanged.

Validation: the original focused file failed with 18 passes and one five-second timeout. The revised file passes all 29 cases under Node20.20.0 and the maintained SafeJS package configuration; the three `co` cases took 2184ms, 2099ms, and 2126ms. A bounded profile attributes most execution time to retained-root collection and recursive data measurement; this PR makes no runtime optimization. CI on the new head remains required.

This one-file PR now starts from current main `ede5985e5e2b35b38eebd0faaeb3ed6a390493e9`, which already contains PR715’s explicit provider models, Kimi registration, built MCP fixture, and Goose catalog fixes. The checkpoint test was unchanged on main. After restoring the updated lockfile dependencies, the rebased change at `a9dc74cdce2cebcd3e42c34111efc3e59058cadc` passes all 29 focused cases; the three `co` cases take 1216ms, 1127ms, and 1182ms under Node20.20.0 with the maintained configuration. Fresh combined CI remains required.

The earlier baseline/profile evidence below remains tied to PR719’s source and the original test change; the screenshot is historical evidence at its explicitly labeled commit.


### Diagnostic test evidence

Actual saved local baseline, phase-trace, and passing-test excerpts, rendered without rerunning tests. The source/config invariance described above ties this evidence to the one-file change at `8f59f4bdd456fdb478202dc89984ca8466aaac74`. This is diagnostic evidence, not product UI or hosted CI clearance.

![Diagnostic test evidence — not product UI](https://github.com/user-attachments/assets/a39a9b9b-44dc-4dfe-8282-279658a133d5)
